### PR TITLE
only copy response data and log when debug

### DIFF
--- a/stream/src/chan/get_by_layer.rs
+++ b/stream/src/chan/get_by_layer.rs
@@ -69,7 +69,11 @@ where
         ))))
     }
 
+    // 打印respose的内容，注意仅仅在Debug开启时才生效执行
     fn log_response(&mut self, item: &Response) {
+        if !log::log_enabled!(log::Level::Debug) {
+            return;
+        }
         // print request and respons
         log::debug!("=================== print response... =================");
         let rsp_its = item.iter();


### PR DESCRIPTION
只有开启debug log时，才准备response的data并打印。