### PR TITLE
支持‘#’做分隔符的key，重构hash，支持单行扩展新分隔符

### DIFF
--- a/endpoint/src/cacheservice/topo.rs
+++ b/endpoint/src/cacheservice/topo.rs
@@ -166,7 +166,13 @@ where
     #[inline]
     fn update(&mut self, namespace: &str, cfg: &str) {
         if let Some(ns) = super::config::Namespace::try_from(cfg, namespace) {
-            self.hasher = Hasher::from(&ns.hash);
+            // 对于mc，crc32实际是crc32-short，这里需要做一次转换
+            let mut hash_name = ns.hash.clone();
+            if hash_name.eq("crc32") {
+                hash_name = "crc32-short".to_string();
+                log::info!("change mc crc32 to crc32-short");
+            }
+            self.hasher = Hasher::from(hash_name.as_str());
             self.exp_sec = (ns.exptime / 1000) as u32; // 转换成秒
             let dist = &ns.distribution;
 

--- a/sharding/src/hash/bkdr.rs
+++ b/sharding/src/hash/bkdr.rs
@@ -13,6 +13,10 @@ impl super::Hash for Bkdr {
             h = h.wrapping_mul(-1);
         }
 
+        if h == 0 {
+            log::error!("found zero hash for key: {:?}", b);
+        }
+
         h as i64
     }
 }

--- a/sharding/src/hash/crc32.rs
+++ b/sharding/src/hash/crc32.rs
@@ -35,6 +35,9 @@ const CRC32TAB: [i64; 256] = [
 
 const CRC_SEED: i64 = 0xFFFFFFFF;
 
+// 用于表示无分隔符的场景
+const DELIMITER_NONE: char = 0 as char;
+
 // 用于兼容jdk版本crc32算法
 #[derive(Default, Clone, Debug)]
 pub struct Crc32 {}
@@ -43,79 +46,169 @@ pub struct Crc32 {}
 #[derive(Default, Clone, Debug)]
 pub struct Crc32Short {}
 
-// 用于redis的区间crc32变种
+// crc32算法，hash key只支持start_pos之后的所有数字，用于兼容混合"."、"_"分割的hash key
 #[derive(Default, Clone, Debug)]
-pub struct Crc32Range {
-    start: usize,
-    hash_key_type: HashKeyType, // 是否只对digit部分进行hash
+pub struct Crc32Num {
+    start_pos: usize,
 }
 
-#[derive(Clone, Debug)]
-pub enum HashKeyType {
-    All,       // 全字符串做hash
-    OnlyDigit, // hash key只是数字子串
-    PointStop, // 截止"."之前的部分，对应业务的getSqlKey
+// Crc32算法，hash key是开始位置之后、分隔符之前的字符串
+#[derive(Default, Clone, Debug)]
+pub struct Crc32Delimiter {
+    start_pos: usize,
+    delimiter: char,
+    name: String,
 }
 
-impl Default for HashKeyType {
-    fn default() -> Self {
-        return HashKeyType::All;
-    }
-}
+impl Crc32Num {
+    pub fn from(alg: &str) -> Self {
+        let alg_parts: Vec<&str> = alg.split("-").collect();
 
-impl Display for HashKeyType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name: &str;
-        match self {
-            Self::All => name = "all",
-            Self::OnlyDigit => name = "onlyDigit",
-            Self::PointStop => name = "pointStop",
+        debug_assert!(alg_parts.len() >= 2);
+        debug_assert_eq!(alg_parts[0], "crc32");
+        debug_assert_eq!(alg_parts[1], "num");
+
+        if alg_parts.len() == 2 {
+            return Self { start_pos: 0 };
         }
-        return write!(f, "{}", name);
+
+        debug_assert_eq!(alg_parts.len(), 3);
+        if let Ok(prefix_len) = alg_parts[2].parse::<usize>() {
+            return Self {
+                start_pos: prefix_len,
+            };
+        } else {
+            log::warn!("use crc32-num for malformed hash: {:?}", alg_parts);
+            return Self { start_pos: 0 };
+        }
     }
 }
 
-// 在start为0且only_num为false时，兼容crc32的原始实现，与java.util.zip.CRC32的多种长度数据的计算结果相同（jdk的CRC32核心算法是native不可见）
-pub(crate) fn crc32_raw<K: super::HashKey>(
-    key: &K,
-    start: usize,
-    hash_key_typ: &HashKeyType,
-) -> i64 {
-    let mut crc: i64 = CRC_SEED;
-    // assert!(start < key.len());
-    for i in start..key.len() {
-        let c = key.at(i);
+impl super::Hash for Crc32Num {
+    fn hash<S: super::HashKey>(&self, key: &S) -> i64 {
+        debug_assert!(self.start_pos < key.len());
 
-        match hash_key_typ {
+        let mut crc: i64 = CRC_SEED;
+        for i in self.start_pos..key.len() {
+            let c = key.at(i);
             // 对于用数字类型做hash，则遇到非数字结束
-            HashKeyType::OnlyDigit => {
-                if !c.is_ascii_digit() {
-                    break;
-                }
+            if !c.is_ascii_digit() {
+                break;
             }
-            // 对于用“.”做分割的sql key，遇到“.”停止
-            HashKeyType::PointStop => {
-                if c == '.' as u8 {
-                    break;
-                }
-            }
-            // do nothing
-            HashKeyType::All => {}
+            crc = ((crc >> 8) & 0x00FFFFFF) ^ CRC32TAB[((crc ^ (c as i64)) & 0xff) as usize];
         }
 
+        crc ^= CRC_SEED;
+        crc &= CRC_SEED;
+        if crc <= 0 {
+            log::warn!(
+                "crc32-num-{} key:{:?}, malform hash:{}",
+                self.start_pos,
+                key,
+                crc
+            );
+        }
+        crc
+    }
+}
+
+impl Display for Crc32Num {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.start_pos == 0 {
+            return write!(f, "{}", "crc32-num");
+        }
+
+        write!(f, "crc32-num-{}", self.start_pos)
+    }
+}
+
+impl Crc32Delimiter {
+    pub fn from(alg: &str) -> Self {
+        let alg_parts: Vec<&str> = alg.split(super::HASHER_NAME_DELIMITER).collect();
+
+        debug_assert!(alg_parts.len() >= 2);
+        debug_assert_eq!(alg_parts[0], "crc32");
+
+        // 如果需要扩展新的分隔符，在这里新增一行即可 fishermen
+        let delimiter = match alg_parts[1] {
+            super::CRC32_EXT_POINT => '.',
+            super::CRC32_EXT_UNDERSCORE => '_',
+            super::CRC32_EXT_POUND => '#',
+            _ => {
+                log::error!("unknow hash alg: {}, use crc32 instead", alg);
+                DELIMITER_NONE
+            }
+        };
+
+        if alg_parts.len() == 2 {
+            return Self {
+                start_pos: 0,
+                delimiter: delimiter,
+                name: alg.to_string(),
+            };
+        }
+
+        debug_assert!(alg_parts.len() == 3);
+        if let Ok(prefix_len) = alg_parts[2].parse::<usize>() {
+            return Self {
+                start_pos: prefix_len,
+                delimiter: delimiter,
+                name: alg.to_string(),
+            };
+        } else {
+            log::error!("found unknown hash/{}, ignore prefix instead", alg);
+            return Self {
+                start_pos: 0,
+                delimiter: delimiter,
+                name: alg.to_string(),
+            };
+        }
+    }
+}
+
+impl super::Hash for Crc32Delimiter {
+    fn hash<S: super::HashKey>(&self, key: &S) -> i64 {
+        let mut crc: i64 = CRC_SEED;
+        debug_assert!(self.start_pos < key.len());
+
+        // 对于用“.”、“_”、“#”做分割的hash key，遇到分隔符停止
+        let check_delimiter = self.delimiter != DELIMITER_NONE;
+        for i in self.start_pos..key.len() {
+            let c = key.at(i);
+            if check_delimiter && (c == self.delimiter as u8) {
+                break;
+            }
+            crc = ((crc >> 8) & 0x00FFFFFF) ^ CRC32TAB[((crc ^ (c as i64)) & 0xff) as usize];
+        }
+
+        crc ^= CRC_SEED;
+        crc &= CRC_SEED;
+        if crc <= 0 {
+            log::error!("{} - malform hash/{} for key/{:?}", self.name, crc, key);
+        }
+        crc
+    }
+}
+
+fn crc32_hash<K: super::HashKey>(key: &K) -> i64 {
+    let mut crc: i64 = CRC_SEED;
+
+    for i in 0..key.len() {
+        let c = key.at(i);
         crc = ((crc >> 8) & 0x00FFFFFF) ^ CRC32TAB[((crc ^ (c as i64)) & 0xff) as usize];
     }
+
     crc ^= CRC_SEED;
     crc &= CRC_SEED;
-    if crc < 0 {
-        log::warn!("negative hash key:{:?},[{}/{}]", key, start, hash_key_typ);
+    if crc <= 0 {
+        log::error!("crc32 - error hash/{} for key/{:?}", crc, key);
     }
     crc
 }
 
 impl super::Hash for Crc32 {
     fn hash<K: super::HashKey>(&self, key: &K) -> i64 {
-        crc32_raw(key, 0, &HashKeyType::All)
+        crc32_hash(key)
     }
 }
 
@@ -123,10 +216,10 @@ impl super::Hash for Crc32 {
 // 理论上应该与线上一致，注意跟进线上不一致场景 fishermen
 impl super::Hash for Crc32Short {
     fn hash<K: super::HashKey>(&self, key: &K) -> i64 {
-        let crc = crc32_raw(key, 0, &HashKeyType::All);
+        let crc = crc32_hash(key);
         let mut rs = (crc >> 16) & 0x7fff;
-        if rs < 0 {
-            log::warn!("found negative crc32 hash for key:{:?}", key);
+        if rs <= 0 {
+            log::warn!("found negative/zero crc32 hash for key:{:?}", key);
             rs = rs.wrapping_mul(-1);
         }
 
@@ -134,80 +227,14 @@ impl super::Hash for Crc32Short {
     }
 }
 
-// 兼容api-commons中redis的crc32 hash算法，同时支持各种场景的hash计算，线上待验证 fishermen
-impl Crc32Range {
-    pub fn from(alg: &str) -> Self {
-        match alg {
-            super::CRC32_RANGE => {
-                // format: crc32-range
-                Self {
-                    start: 0,
-                    hash_key_type: HashKeyType::All,
-                }
-            }
-            super::CRC32_RANGE_ID => {
-                // format: crc32-range-id
-                Self {
-                    start: 0,
-                    hash_key_type: HashKeyType::OnlyDigit,
-                }
-            }
-            super::CRC32_RANGE_POINT => {
-                // format: crc32-range-point
-                Self {
-                    start: 0,
-                    hash_key_type: HashKeyType::PointStop,
-                }
-            }
-            _ => {
-                // format: crc32-range-id-xxx，如果xxx不是合法数字，则直接使用全部的key来hash
-                // crc32-range-id: 从key的第一个数字开始解析id；
-                // crc32-range-id-2： 掠过2个字节的前缀，然后开始解析数字
-                assert!(alg.len() > (super::CRC32_RANGE_ID_PREFIX.len()));
-                let start = &alg[super::CRC32_RANGE_ID_PREFIX.len()..];
-                if let Ok(s) = start.parse::<usize>() {
-                    return Self {
-                        start: s,
-                        hash_key_type: HashKeyType::OnlyDigit,
-                    };
-                } else {
-                    log::warn!("use crc32-range for fingding malformed hash: {}", alg);
-                    return Self {
-                        start: 0,
-                        hash_key_type: HashKeyType::All,
-                    };
-                }
-            }
-        }
-    }
-}
-
-impl super::Hash for Crc32Range {
-    fn hash<K: super::HashKey>(&self, key: &K) -> i64 {
-        let crc = crc32_raw(key, self.start, &self.hash_key_type);
-        crc
-    }
-}
-
-// impl Crc32 {
-//     // crc-32 标准规范实现，与mc/jdk实现存在差异
-//     fn _hash_spec(&mut self, key: &[u8]) -> u64 {
-//         let mut crc: i64 = !0;
-//         for c in key {
-//             crc = CRC32TAB[((crc ^ *c as i64) & 0xFF) as usize] ^ (crc >> 8);
-//         }
-//         return (crc ^ !0) as u64;
-//     }
-// }
-
 use std::fmt::Display;
 
 #[cfg(test)]
 mod crc_test {
 
-    use crate::{bkdr::Bkdr, distribution::Distribute, Hash};
+    use crate::{bkdr::Bkdr, distribution::Distribute, hash::Crc32Delimiter, Hash};
 
-    use super::{Crc32Range, Crc32Short};
+    use super::Crc32Short;
 
     #[test]
     fn crc32_mc_test() {
@@ -226,7 +253,7 @@ mod crc_test {
     fn crc32_redis_test() {
         println!("===========crc32-redis test start...");
         let key = "4711424389024351.repost";
-        let crc32 = Crc32Range::from("crc32-range-id-0");
+        let crc32 = Crc32Delimiter::from("crc32-id-0");
         let hash = crc32.hash(&key.as_bytes());
 
         let mut shards = Vec::with_capacity(8);

--- a/sharding/src/hash/mod.rs
+++ b/sharding/src/hash/mod.rs
@@ -18,6 +18,7 @@ pub trait Hash {
 pub enum Hasher {
     Raw(Raw), // redis raw, long型字符串直接用数字作为hash
     Bkdr(Bkdr),
+    Crc32(Crc32),
     Crc32Short(Crc32Short),         // mc short crc32
     Crc32Num(Crc32Num),             // crc32 for a hash key whick is a num,
     Crc32Delimiter(Crc32Delimiter), // crc32 for a hash key which has a delimiter of "." or "_" or "#" etc.
@@ -80,7 +81,7 @@ impl Hasher {
             return match alg_parts[0] {
                 "bkdr" => Self::Bkdr(Default::default()),
                 "raw" => Self::Raw(Raw::from(Default::default())),
-                "crc32" => Self::Crc32Delimiter(Default::default()),
+                "crc32" => Self::Crc32(Default::default()),
                 _ => {
                     // 默认采用mc的crc32-s hash
                     log::debug!("found unknow hash:{}, use crc32-short instead", alg);

--- a/sharding/src/hash/mod.rs
+++ b/sharding/src/hash/mod.rs
@@ -16,41 +16,88 @@ pub trait Hash {
 #[enum_dispatch(Hash)]
 #[derive(Debug, Clone)]
 pub enum Hasher {
+    Raw(Raw), // redis raw, long型字符串直接用数字作为hash
     Bkdr(Bkdr),
-    Crc32Short(Crc32Short), // mc short crc32
-    Crc32Range(Crc32Range), // redis crc32 range hash
-    Raw(Raw),               // redis raw, long型字符串直接用数字作为hash
+    Crc32Short(Crc32Short),         // mc short crc32
+    Crc32Num(Crc32Num),             // crc32 for a hash key whick is a num,
+    Crc32Delimiter(Crc32Delimiter), // crc32 for a hash key which has a delimiter of "." or "_" or "#" etc.
 }
 
 // crc32-short和crc32-range长度相同，所以此处选一个
-const CRC32_RANGE_OR_SHORT_LEN: usize = "crc32-range".len();
-// 使用整个key做hash
-const CRC32_RANGE: &str = "crc32-range";
-// 对整个key中的第一串数字做hash
-const CRC32_RANGE_ID: &str = "crc32-range-id";
-// skip掉xxx个字节，然后对剩余key中的第一串数字做hash
-const CRC32_RANGE_ID_PREFIX: &str = "crc32-range-id-";
-// 兼容业务中的getSqlKey方式，即用"."之前内容做hash
-const CRC32_RANGE_POINT: &str = "crc32-range-point";
+// const CRC32_RANGE_OR_SHORT_LEN: usize = "crc32-range".len();
+
+// // 使用整个key做hash
+// const CRC32_RANGE: &str = "crc32-range";
+// // 对整个key中的第一串数字做hash
+// const CRC32_RANGE_ID: &str = "crc32-range-id";
+// // skip掉xxx个字节，然后对剩余key中的第一串数字做hash
+// const CRC32_RANGE_ID_PREFIX: &str = "crc32-range-id-";
+// // 兼容业务中的getSqlKey方式，即用"."之前内容做hash
+// const CRC32_RANGE_POINT: &str = "crc32-range-point";
+// const CRC32_CORE: &str = "crc32";
+
+// hash算法名称分隔符，合法的算法如：crc32,crc-short, crc32-num, crc32-point, crc32-pound, crc32-underscore
+const HASHER_NAME_DELIMITER: char = '-';
+
+// hash key是全部的key，但最后要做short截断
+const CRC32_EXT_SHORT: &str = "short";
+// hash key是数字
+const CRC32_EXT_NUM: &str = "num";
+// hash key是点号"."之前的部分
+const CRC32_EXT_POINT: &str = "point";
+// hash key是“#”之前的部分
+const CRC32_EXT_POUND: &str = "pound";
+// hash key是"_"之前的部分
+const CRC32_EXT_UNDERSCORE: &str = "underscore";
 
 impl Hasher {
-    pub fn from(alg: &str) -> Self {
-        let alg_lower = alg.to_ascii_lowercase();
-        let mut alg_match = alg_lower.as_str();
-        if alg_match.len() > CRC32_RANGE_OR_SHORT_LEN {
-            alg_match = &alg_match[0..CRC32_RANGE_OR_SHORT_LEN];
+    // 主要做3件事：1）将hash alg转为小写；2）兼容xx-range；3）兼容-id为-num
+    fn reconcreate_hash_name(alg: &str) -> String {
+        let mut alg_lower = alg.to_ascii_lowercase();
+
+        // 如果alg带有range的hash名称（即crc32-range-xxx or crc32-range），需要去掉"-range"
+        let range_flag = "-range";
+        if alg_lower.contains(range_flag) {
+            alg_lower = alg_lower.replace(range_flag, "");
+            log::warn!("replace old range hash name/{} with {}", alg, alg_lower);
         }
 
-        match alg_match {
-            "bkdr" => Self::Bkdr(Default::default()),
-            "crc32-short" => Self::Crc32Short(Default::default()),
-            "crc32-range" => Self::Crc32Range(Crc32Range::from(alg_lower.as_str())),
-            "raw" => Self::Raw(Raw::from(Default::default())),
-            _ => {
-                // 默认采用mc的crc32-s hash
-                log::debug!("found unknow hash:{}, use crc32-short instead", alg);
-                Self::Crc32Short(Default::default())
-            } // _ => Self::Crc32(Default::default()),
+        // 如果alg带有"-id"，需要把"-id"换为"-num"，like crc32-id => crc32-num
+        let id_flag = "-id";
+        if alg_lower.contains(id_flag) {
+            alg_lower = alg_lower.replace(id_flag, "-num");
+            log::warn!("replace old id hash name/{} with {}", alg, alg_lower);
+        }
+
+        alg_lower
+    }
+    pub fn from(alg: &str) -> Self {
+        let alg_lower = Hasher::reconcreate_hash_name(alg);
+        let alg_parts: Vec<&str> = alg_lower.split(HASHER_NAME_DELIMITER).collect();
+
+        // 简单hash，即名字中没有"-"的hash，目前只有bkdr、raw、crc32
+        if alg_parts.len() == 1 {
+            return match alg_parts[0] {
+                "bkdr" => Self::Bkdr(Default::default()),
+                "raw" => Self::Raw(Raw::from(Default::default())),
+                "crc32" => Self::Crc32Delimiter(Default::default()),
+                _ => {
+                    // 默认采用mc的crc32-s hash
+                    log::debug!("found unknow hash:{}, use crc32-short instead", alg);
+                    return Self::Crc32Short(Default::default());
+                }
+            };
+        }
+
+        // crc32 扩展hash，目前包含3类：short、num、delimiter，前两种为：crc32-short, crc-32-num
+        // crc32-delimiter包括各种可扩展的分隔符，like： crc32-point, crc32-pound,crc32-underscore；
+        // 如果业务有固定前缀，也可以支持，在hash name后加-xxx，xxx为前缀长度。
+        debug_assert!(alg_parts.len() == 2 || alg_parts.len() == 3);
+        debug_assert!(alg_parts[0].eq("crc32"));
+        match alg_parts[1] {
+            CRC32_EXT_SHORT => Self::Crc32Short(Default::default()),
+            CRC32_EXT_NUM => Self::Crc32Num(Crc32Num::from(alg_lower.as_str())),
+            _ => Self::Crc32Delimiter(Crc32Delimiter::from(alg_lower.as_str())),
         }
     }
     #[inline]

--- a/sharding/src/hash/raw.rs
+++ b/sharding/src/hash/raw.rs
@@ -12,6 +12,10 @@ impl super::Hash for Raw {
             hash = hash * 10 + (key.at(i) - '0' as u8) as i64;
         }
 
+        if hash <= 0 {
+            log::error!("found malform hash/{} for key: {:?}", hash, key);
+        }
+
         hash
     }
 }

--- a/sharding/src/lib.rs
+++ b/sharding/src/lib.rs
@@ -14,35 +14,36 @@ use distribution::*;
 mod select;
 pub use select::*;
 
-use std::ops::Deref;
+// use std::ops::Deref;
 
 impl Sharding {
-    pub fn from(hash_alg: &str, distribution: &str, names: Vec<String>) -> Self {
-        let num = names.len();
-        let h = Hasher::from(hash_alg);
-        let d = Distribute::from(distribution, &names);
-        Self {
-            hash: h,
-            distribution: d,
-            num: num,
-        }
-    }
-    #[inline]
-    pub fn sharding(&self, key: &[u8]) -> usize {
-        let hash = self.hash.hash(&key);
-        let idx = self.distribution.index(hash);
-        assert!(idx < self.num);
-        idx
-    }
-    // key: sharding idx
-    // value: 是keys idx列表
-    #[inline]
-    pub fn shardings<K: Deref<Target = [u8]>>(&self, keys: Vec<K>) -> Vec<Vec<usize>> {
-        let mut shards = vec![Vec::with_capacity(8); self.num];
-        for (ki, key) in keys.iter().enumerate() {
-            let idx = self.sharding(key);
-            unsafe { shards.get_unchecked_mut(idx).push(ki) };
-        }
-        shards
-    }
+    // dead code 暂时注释掉
+    // pub fn from(hash_alg: &str, distribution: &str, names: Vec<String>) -> Self {
+    //     let num = names.len();
+    //     let h = Hasher::from(hash_alg);
+    //     let d = Distribute::from(distribution, &names);
+    //     Self {
+    //         hash: h,
+    //         distribution: d,
+    //         num: num,
+    //     }
+    // }
+    // #[inline]
+    // pub fn sharding(&self, key: &[u8]) -> usize {
+    //     let hash = self.hash.hash(&key);
+    //     let idx = self.distribution.index(hash);
+    //     assert!(idx < self.num);
+    //     idx
+    // }
+    // // key: sharding idx
+    // // value: 是keys idx列表
+    // #[inline]
+    // pub fn shardings<K: Deref<Target = [u8]>>(&self, keys: Vec<K>) -> Vec<Vec<usize>> {
+    //     let mut shards = vec![Vec::with_capacity(8); self.num];
+    //     for (ki, key) in keys.iter().enumerate() {
+    //         let idx = self.sharding(key);
+    //         unsafe { shards.get_unchecked_mut(idx).push(ki) };
+    //     }
+    //     shards
+    // }
 }


### PR DESCRIPTION
1. 支持#作为分隔符进行key hash；
2. 重构hash，支持3类key，同时对crc32-delimiter模式，可以一行代码扩展新的分隔符。