### PR TITLE
修改phantom协议处理

### DIFF
--- a/endpoint/src/phantomservice/topo.rs
+++ b/endpoint/src/phantomservice/topo.rs
@@ -112,7 +112,6 @@ where
         if idx >= self.streams.len() {
             return (idx, false);
         }
-        log::debug!("+++ will check access mod");
         let stream_mod = &self.streams.get(idx).unwrap().1;
         while (ctx.is_write() && !stream_mod.can_write())
             || (!ctx.is_write() && !stream_mod.can_read())

--- a/protocol/src/phantom/command.rs
+++ b/protocol/src/phantom/command.rs
@@ -278,7 +278,7 @@ lazy_static! {
                 ("bfget" , "bfget",        2, Get, 1, 1, 1, 3, false, false, true, false, false),
                 ("bfmget", "bfget",       -2, MGet, 1, -1, 1, 3, true, false, true, false, true),
                 ("bfset", "bfset",         2, Store, 1, 1, 1, 3, false, false, true, false, false),
-                ("bfmset", "bfmset",       -2, Store, 1, 1, 1, 3, true, false, true, false, true),
+                ("bfmset", "bfset",       -2, Store, 1, 1, 1, 3, true, false, true, false, true),
 
 
 

--- a/stream/src/handler.rs
+++ b/stream/src/handler.rs
@@ -74,7 +74,6 @@ impl<'r, Req, P, S> Handler<'r, Req, P, S> {
         while let Some(req) = ready!(self.data.poll_recv(cx)) {
             self.num_tx += 1;
             self.s.write_slice(req.data(), 0)?;
-            log::debug!("+++++ write req:{:?}", req.data().utf8());
             match req.on_sent() {
                 Some(r) => self.pending.push_back(r),
                 None => {
@@ -98,12 +97,11 @@ impl<'r, Req, P, S> Handler<'r, Req, P, S> {
             // num == 0 说明是buffer满了。等待下一次事件，buffer释放后再读取。
             let num = reader.check_eof_num()?;
             if num == 0 {
-                log::debug!("++++++ buffer full:{:?}", self);
                 log::debug!("buffer full:{:?}", self);
                 // TODO: 可能触发多次重试失败。
                 return Poll::Ready(Err(Error::ResponseBufferFull));
             }
-            log::debug!("++++++ {} bytes received. {:?}", num, self);
+
             log::debug!("{} bytes received. {:?}", num, self);
             while self.buf.len() > 0 {
                 match self.parser.parse_response(&mut self.buf)? {
@@ -114,7 +112,6 @@ impl<'r, Req, P, S> Handler<'r, Req, P, S> {
                         self.num_rx += 1;
                         // 统计请求耗时。
                         self.rtt += req.start_at().elapsed();
-                        use protocol::Utf8;
                         assert!(
                             self.parser.check(req.cmd(), &cmd),
                             "{:?} {:?} => {:?}",


### PR DESCRIPTION
1 对所有负数rsp均重试，包括疑似非法key-2（因为非法key跟实例判断有关，如果不重试，在后续phantom升级可能会遇到问题）；   
2 调整bfmset的返回格式。 