### PR TITLE
1 filter err for multi cmds; 2 support reading socks from vintage

### DIFF
--- a/agent/src/http.rs
+++ b/agent/src/http.rs
@@ -7,8 +7,8 @@ pub(super) fn start_http_server(ctx: &context::Context, rt: &tokio::runtime::Run
     rt.spawn(api::start_whitelist_refresh(ctx.whitelist_host.clone()));
     log::info!("launch with rocket!");
     rt.spawn(async {
-        if let Err(e) = api::routes().launch().await {
-            log::error!("launch rocket failed: {:?}", e);
+        if let Err(_e) = api::routes().launch().await {
+            log::error!("launch rocket failed: {:?}", _e);
         };
     });
 }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -64,6 +64,11 @@ async fn run(ctx: Context) -> Result<()> {
     let tick = ctx.tick();
     let mut fix = discovery::Fixed::default();
     fix.register(ctx.idc_path(), discovery::distance::build_refresh_idc());
+    // 从vintage获取socks
+    fix.register(
+        ctx.service_pool_path(),
+        discovery::socks::build_refresh_socks(ctx.service_path()),
+    );
     rt::spawn(watch_discovery(snapshot, discovery, rx, tick, fix));
 
     log::info!("server({}) inited {:?}", context::get_short_version(), ctx);
@@ -72,6 +77,7 @@ async fn run(ctx: Context) -> Result<()> {
     listeners.remove_unix_sock().await?;
     loop {
         let (quards, failed) = listeners.scan().await;
+
         if failed > 0 {
             metrics::set_sockfile_failed(failed);
         }

--- a/agent/src/service.rs
+++ b/agent/src/service.rs
@@ -1,9 +1,9 @@
+use context::Quadruple;
 use net::Listener;
 use rt::spawn;
 use std::sync::Arc;
 use std::time::Duration;
 
-use context::Quadruple;
 use discovery::TopologyWriteGuard;
 use ds::chan::Sender;
 use metrics::Path;

--- a/agent/src/service.rs
+++ b/agent/src/service.rs
@@ -29,8 +29,6 @@ pub(super) async fn process_one(
 
     let mut listen_failed = Path::new(vec![quard.protocol()]).status("listen_failed");
 
-    // 在业务初始化及监听完成之前，计数加1，成功后再-1，
-
     // 等待初始化完成
     let mut tries = 0usize;
     while !rx.inited() {
@@ -38,7 +36,7 @@ pub(super) async fn process_one(
         let sleep = if tries <= 10 {
             Duration::from_secs(1)
         } else {
-            // 监听失败增加计数
+            // 拉取配置失败，业务监听失败数+1
             listen_failed += 1;
             log::warn!("waiting inited. {} tries:{}", quard, tries);
             // Duration::from_secs(1 << (tries.min(10)))
@@ -59,6 +57,8 @@ pub(super) async fn process_one(
 
     // 服务注册完成，侦听端口直到成功。
     while let Err(_e) = _process_one(quard, &p, &top, &path).await {
+        // 监听失败或accept连接失败，对监听失败数+1
+        listen_failed += 1;
         log::warn!("service process failed. {}, err:{:?}", quard, _e);
         tokio::time::sleep(Duration::from_secs(6)).await;
     }

--- a/context/Cargo.toml
+++ b/context/Cargo.toml
@@ -15,5 +15,6 @@ tokio = { version = "1.20.1", features = ["fs"] }
 git-version = "0.3.5"
 lazy_static = "1.4.0"
 
+
 [features]
 listen-all = []

--- a/context/Cargo.toml
+++ b/context/Cargo.toml
@@ -15,6 +15,5 @@ tokio = { version = "1.20.1", features = ["fs"] }
 git-version = "0.3.5"
 lazy_static = "1.4.0"
 
-
 [features]
 listen-all = []

--- a/context/src/lib.rs
+++ b/context/src/lib.rs
@@ -32,6 +32,13 @@ pub struct Context {
     discovery: Url,
 
     #[clap(
+        long,
+        help("registry url prefix. e.g. static.config.xxx.xxx"),
+        default_value("")
+    )]
+    url_prefix: String,
+
+    #[clap(
         short,
         long,
         help("idc config path"),
@@ -154,15 +161,24 @@ impl Context {
     pub fn snapshot(&self) -> &str {
         &self.snapshot
     }
-    pub fn idc_path(&self) -> String {
+    pub fn idc_path_url(&self) -> String {
+        // idc-path参数
+        if self.url_prefix.len() > 0 && !self.idc_path.contains(&self.url_prefix.to_string()) {
+            return format!("{}/{}", self.url_prefix, self.idc_path);
+        }
         self.idc_path.clone()
     }
+    // 服务池名
     pub fn service_pool(&self) -> String {
         self.service_pool.clone()
     }
-    // 从vintage获取service pool的访问path
-    pub fn service_pool_path(&self) -> String {
-        self.service_pool.clone()
+    // 服务池socks url
+    pub fn service_pool_socks_url(&self) -> String {
+        if self.url_prefix.len() > 0 {
+            let socks_path = "3/config/datamesh/config";
+            return format!("{}/{}/{}", self.url_prefix, socks_path, self.service_pool);
+        }
+        Default::default()
     }
 }
 

--- a/context/src/lib.rs
+++ b/context/src/lib.rs
@@ -162,7 +162,7 @@ impl Context {
     }
     // 从vintage获取service pool的访问path
     pub fn service_pool_path(&self) -> String {
-        format!("3/config/datamesh/config/{}", self.service_pool)
+        self.service_pool.clone()
     }
 }
 

--- a/context/src/lib.rs
+++ b/context/src/lib.rs
@@ -160,6 +160,10 @@ impl Context {
     pub fn service_pool(&self) -> String {
         self.service_pool.clone()
     }
+    // 从vintage获取service pool的访问path
+    pub fn service_pool_path(&self) -> String {
+        format!("3/config/datamesh/config/{}", self.service_pool)
+    }
 }
 
 use std::collections::HashMap;

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -1,6 +1,8 @@
 pub(crate) mod cache;
 pub(crate) mod cfg;
 pub mod distance;
+pub mod socks;
+
 mod topology;
 mod update;
 mod vintage;

--- a/discovery/src/socks.rs
+++ b/discovery/src/socks.rs
@@ -1,0 +1,122 @@
+// 用于从vintage获取socks，并将socks文件在socks目录构建
+
+use std::{
+    collections::HashSet,
+    fs::{self, OpenOptions},
+    sync::Mutex,
+};
+
+use ds::{CowReadHandle, CowWriteHandle};
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Socks {
+    #[serde(default)]
+    socklist: HashSet<String>,
+
+    #[serde(skip)]
+    socks_path: String,
+}
+
+pub static SOCKS: OnceCell<CowReadHandle<Socks>> = OnceCell::new();
+static SOCKS_W: OnceCell<Mutex<CowWriteHandle<Socks>>> = OnceCell::new();
+
+pub fn build_refresh_socks(socks_path: String) -> impl Fn(&str) {
+    let (w, r) = ds::cow(Socks::from(socks_path));
+    if let Err(_) = SOCKS.set(r) {
+        panic!("duplicate init socks");
+    }
+    if let Err(_) = SOCKS_W.set(Mutex::from(w)) {
+        panic!("duplicate init socks for writing");
+    }
+    refresh_socks
+}
+
+fn refresh_socks(cfg: &str) {
+    if let Ok(mut socks) = SOCKS_W.get().expect("not init w socks").try_lock() {
+        socks.write(|s| s.refresh(cfg));
+    }
+}
+
+impl Socks {
+    fn from(socks_path: String) -> Self {
+        Self {
+            socks_path,
+            ..Default::default()
+        }
+    }
+    fn refresh(&mut self, cfg: &str) {
+        // 如果socklist为空，应该是刚启动，sockslist尝试从本地加载
+        if self.socklist.len() == 0 {
+            self.socklist = self.load_socks();
+            log::info!("load dir/{} socks: {:?}", self.socks_path, self.socklist);
+        }
+
+        // 解析vintge配置，获得新的socklist
+        match serde_yaml::from_str::<Socks>(cfg) {
+            Ok(ns) => {
+                if ns.socklist.len() == 0 {
+                    log::info!("ignore refresh for socklist in vintage is empty");
+                    return;
+                }
+                log::info!("will update socks to: {:?}", ns.socklist);
+                // 先找到新上线的sock文件和下线的sock文件
+                let mut deleted = Vec::with_capacity(2);
+                for s in self.socklist.iter() {
+                    if !ns.socklist.contains(s) {
+                        deleted.push(s);
+                    }
+                }
+
+                let mut added = Vec::with_capacity(2);
+                for s in ns.socklist.iter() {
+                    if !self.socklist.contains(s) {
+                        added.push(s);
+                    }
+                }
+
+                // 构建新上线的sock文件
+                for n in added {
+                    let fname = format!("{}/{}", self.socks_path, n);
+                    match OpenOptions::new()
+                        .write(true)
+                        .create(true)
+                        .open(fname.clone())
+                    {
+                        Ok(_f) => log::info!("create sock/{} succeed!", fname),
+                        Err(_e) => log::warn!("create sock/{} failed: {:?}!", fname, _e),
+                    }
+                }
+
+                // 删除下线的socks文件
+                for d in deleted {
+                    let fname = format!("{}/{}", self.socks_path, d);
+                    match fs::remove_file(fname.clone()) {
+                        Ok(_f) => log::info!("delete sock/{} succeed!", fname),
+                        Err(_e) => log::warn!("delete sock/{} failed: {:?}", fname, _e),
+                    }
+                }
+            }
+            Err(_e) => log::warn!("parse socks file failed: {:?}, cfg:{} ", _e, cfg),
+        }
+    }
+
+    fn load_socks(&self) -> HashSet<String> {
+        // socks 目录必须存在且可读
+        let mut socks = HashSet::with_capacity(8);
+        let rdir = fs::read_dir(self.socks_path.clone()).unwrap();
+        for entry in rdir.into_iter() {
+            if let Ok(d) = entry {
+                if let Ok(f) = d.file_type() {
+                    if f.is_file() {
+                        if let Some(fname) = d.file_name().to_str() {
+                            socks.insert(fname.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        socks
+    }
+}

--- a/protocol/src/error.rs
+++ b/protocol/src/error.rs
@@ -24,7 +24,7 @@ pub enum Error {
     TopChanged,
     WriteResponseErr,
     NoResponseFound,
-    CommandNotSupported,
+    // CommandNotSupported,
     ResponseBufferFull,
     Quit,
     Timeout(Duration),

--- a/protocol/src/parser.rs
+++ b/protocol/src/parser.rs
@@ -32,14 +32,20 @@ pub trait Proto: Unpin + Clone + Send + Sync + 'static {
         process: &mut P,
     ) -> Result<()>;
     fn parse_response<S: Stream>(&self, data: &mut S) -> Result<Option<Command>>;
-    fn write_response<C: Commander, W: crate::Writer>(&self, ctx: &mut C, w: &mut W) -> Result<()>;
+    // 返回nil convert的数量
+    fn write_response<C: Commander, W: crate::Writer>(
+        &self,
+        ctx: &mut C,
+        w: &mut W,
+    ) -> Result<usize>;
+    // 返回nil convert的数量
     #[inline]
     fn write_no_response<W: crate::Writer, F: Fn(i64) -> usize>(
         &self,
         _req: &HashedCommand,
         _w: &mut W,
         _dist_fn: F,
-    ) -> Result<()> {
+    ) -> Result<usize> {
         Err(Error::NoResponseFound)
     }
     #[inline]

--- a/protocol/src/phantom/command.rs
+++ b/protocol/src/phantom/command.rs
@@ -39,7 +39,7 @@ pub const PADDING_RSP_TABLE: [&str; 6] = [
     "+PONG\r\n",
     "-ERR phantom no available\r\n",
     "-ERR unknown command\r\n",
-    "-10",
+    ":-10\r\n",
 ];
 
 #[allow(dead_code)]

--- a/protocol/src/phantom/command.rs
+++ b/protocol/src/phantom/command.rs
@@ -21,6 +21,7 @@ pub(crate) struct CommandProperties {
     key_step: u8,
     // 指令在不路由或者无server响应时的响应位置，
     pub(super) padding_rsp: u8,
+    pub(super) nil_rsp: u8,
     pub(super) has_val: bool,
     pub(super) has_key: bool,
     pub(super) noforward: bool,
@@ -30,14 +31,15 @@ pub(crate) struct CommandProperties {
     pub(super) need_bulk_num: bool, // mset所有的请求只返回一个+OK，不需要在首个请求前加*bulk_num。其他的都需要
 }
 
-// 默认响应
-// 第0个表示quit
-pub const PADDING_RSP_TABLE: [&str; 5] = [
+// 默认响应,第0个表示qui;
+// bfmget、bfmset在key异常响应时，返回-10作为nil
+pub const PADDING_RSP_TABLE: [&str; 6] = [
     "",
     "+OK\r\n",
     "+PONG\r\n",
     "-ERR phantom no available\r\n",
     "-ERR unknown command\r\n",
+    "-10",
 ];
 
 #[allow(dead_code)]
@@ -201,7 +203,7 @@ impl Commands {
         if cmd.supported {
             Ok(cmd)
         } else {
-            Err(crate::Error::CommandNotSupported)
+            Err(crate::Error::ProtocolNotSupported)
         }
     }
     // 不支持会返回协议错误
@@ -233,6 +235,13 @@ impl Commands {
         assert!(idx < self.supported.len());
         // 之前没有添加过。
         assert!(!self.supported[idx].supported);
+
+        // bfmget、bfmset，在部分key 返回异常响应时，需要将异常信息转换为nil返回 fishermen
+        let mut nil_rsp = 0;
+        if uppercase.eq("BFMGET") || uppercase.eq("BFMSET") {
+            nil_rsp = 5;
+        }
+
         self.supported[idx] = CommandProperties {
             name,
             mname,
@@ -243,6 +252,7 @@ impl Commands {
             last_key_index,
             key_step,
             padding_rsp,
+            nil_rsp,
             noforward,
             supported: true,
             multi,
@@ -276,8 +286,10 @@ lazy_static! {
                 ("quit", "quit" ,          2, Meta, 0, 0, 0, 0, false, true, false, false, false),
 
                 ("bfget" , "bfget",        2, Get, 1, 1, 1, 3, false, false, true, false, false),
-                ("bfmget", "bfget",       -2, MGet, 1, -1, 1, 3, true, false, true, false, true),
                 ("bfset", "bfset",         2, Store, 1, 1, 1, 3, false, false, true, false, false),
+
+                // bfmget、bfmset，在部分key 返回异常响应时，需要将异常信息转换为nil返回 fishermen
+                ("bfmget", "bfget",       -2, MGet, 1, -1, 1, 3, true, false, true, false, true),
                 ("bfmset", "bfset",       -2, Store, 1, 1, 1, 3, true, false, true, false, true),
 
 

--- a/protocol/src/redis/command.rs
+++ b/protocol/src/redis/command.rs
@@ -50,7 +50,7 @@ pub const PADDING_RSP_TABLE: [&str; 7] = [
     "-ERR redis no available\r\n",
     "-ERR invalid command\r\n",
     "-ERR should swallowed in mesh\r\n", // 仅仅占位，会在mesh内吞噬掉，不会返回给client or server
-    "$-1",                               // mget 等指令对应的nil
+    "$-1\r\n",                           // mget 等指令对应的nil
 ];
 
 #[allow(dead_code)]

--- a/protocol/src/redis/command.rs
+++ b/protocol/src/redis/command.rs
@@ -295,6 +295,7 @@ lazy_static! {
     pub(super) static ref SUPPORTED: Commands = {
         let mut cmds = Commands::new();
         use Operation::*;
+    // TODO：后续增加新指令时，当multi/need_bulk_num 均为true时，需要在add_support中进行nil转换，避免将err返回到client fishermen
     for (name, mname, arity, op, first_key_index, last_key_index, key_step, padding_rsp, multi, noforward, has_key, has_val, need_bulk_num)
         in vec![
                 // meta 指令

--- a/protocol/src/redis/command.rs
+++ b/protocol/src/redis/command.rs
@@ -28,6 +28,7 @@ pub(crate) struct CommandProperties {
     key_step: u8,
     // 指令在不路由或者无server响应时的响应位置，
     pub(super) padding_rsp: u8,
+    pub(super) nil_rsp: u8,
     pub(super) has_val: bool,
     pub(super) has_key: bool,
     pub(super) noforward: bool,
@@ -42,13 +43,14 @@ pub(crate) struct CommandProperties {
 
 // 默认响应
 // 第0个表示quit
-pub const PADDING_RSP_TABLE: [&str; 6] = [
+pub const PADDING_RSP_TABLE: [&str; 7] = [
     "",
     "+OK\r\n",
     "+PONG\r\n",
     "-ERR redis no available\r\n",
     "-ERR invalid command\r\n",
     "-ERR should swallowed in mesh\r\n", // 仅仅占位，会在mesh内吞噬掉，不会返回给client or server
+    "$-1",                               // mget 等指令对应的nil
 ];
 
 #[allow(dead_code)]
@@ -189,7 +191,7 @@ impl Commands {
         if cmd.supported {
             Ok(cmd)
         } else {
-            Err(crate::Error::CommandNotSupported)
+            Err(crate::Error::ProtocolNotSupported)
         }
     }
     // 不支持会返回协议错误
@@ -250,6 +252,11 @@ impl Commands {
         // 需要前一个指令明确指定hash的目前只有lua下面3个指令
         let need_reserved_hash =
             uppercase.eq("EVAL") || uppercase.eq("EVALSHA") || uppercase.eq("SCRIPT");
+        // 目前只有mget指令是MGet/MINCR类型，才需要nil
+        let mut nil_rsp = 0;
+        if uppercase.eq("MGET") || uppercase.eq("MINCR") {
+            nil_rsp = 6;
+        }
 
         self.supported[idx] = CommandProperties {
             name,
@@ -261,6 +268,7 @@ impl Commands {
             last_key_index,
             key_step,
             padding_rsp,
+            nil_rsp,
             noforward,
             supported: true,
             multi,
@@ -298,15 +306,20 @@ lazy_static! {
                 ("quit", "quit" ,          2, Meta, 0, 0, 0, 0, false, true, false, false, false),
 
                 ("get" , "get",            2, Get, 1, 1, 1, 3, false, false, true, false, false),
+
+                // multi请求：异常响应需要改为$-1
                 ("mget", "get",           -2, MGet, 1, -1, 1, 3, true, false, true, false, true),
 
                 ("set" ,"set",             3, Store, 1, 1, 1, 3, false, false, true, true, false),
                 ("incr" ,"incr",           2, Store, 1, 1, 1, 3, false, false, true, false, false),
                 ("decr" ,"decr",           2, Store, 1, 1, 1, 3, false, false, true, false, false),
+
+                // multi请求：异常响应需要改为$-1
                 ("mincr","mincr",         -2, Store, 1, -1, 1, 3, true, false, true, false, true),
+
+                //mset、del 是mlti指令，但只返回一个result，即need_bulk_num为false，那就只返回第一个key的响应 fishermen
                 // mset不需要bulk number
                 ("mset", "set",           -3, Store, 1, -1, 2, 3, true, false, true, true, false),
-
                 // TODO: del 删除多个key时，返回删除的key数量，先不聚合这个数字，反正client也会忽略？ fishermen
                 ("del", "del",            -2, Store, 1, -1, 1, 3, true, false, true, false, false),
 

--- a/protocol/src/redis/mod.rs
+++ b/protocol/src/redis/mod.rs
@@ -300,9 +300,6 @@ impl Protocol for Redis {
                 }
 
                 return w.write_slice(response.data(), 0);
-
-                log::debug!("+++ ignore non-first rsp for cmd: {:?}", cfg.name);
-                Ok(())
             } else {
                 // 有些请求，如mset，不需要bulk_num,说明只需要返回一个首个key的请求即可。
                 // mset always return +OK

--- a/protocol/src/redis/mod.rs
+++ b/protocol/src/redis/mod.rs
@@ -47,7 +47,15 @@ impl Redis {
             let master_only = packet.parse_cmd_layer()?;
             packet.parse_bulk_num()?;
             packet.parse_cmd()?;
-            let cfg = command::get_cfg(packet.op_code())?;
+            // 对于不支持的cmd，记录协议
+            let cfg = match command::get_cfg(packet.op_code()) {
+                Ok(cfg) => cfg,
+                Err(super::Error::ProtocolNotSupported) => {
+                    log::warn!("+++ found unsupported req:{:?}", stream.slice().utf8());
+                    return Err(super::Error::ProtocolNotSupported);
+                }
+                Err(e) => return Err(e),
+            };
             let mut hash;
             if cfg.swallowed {
                 // 优先处理swallow吞噬指令: hashkeyq/hashrandomq
@@ -275,7 +283,26 @@ impl Protocol for Redis {
                     w.write(ext.key_count().to_string().as_bytes())?;
                     w.write(b"\r\n")?;
                 }
-                w.write_slice(response.data(), 0)
+
+                // 对于每个key均需要响应，且响应是异常的场景，返回nil，否则继续返回原响应
+                if ext.key_count() > 0
+                    && cfg.need_bulk_num
+                    && response.data().at(0) == b'-'
+                    && cfg.nil_rsp > 0
+                {
+                    let nil = *PADDING_RSP_TABLE.get(cfg.nil_rsp as usize).unwrap();
+                    log::debug!(
+                        "+++ use {} to replace err rsp: {:?}",
+                        nil,
+                        response.data().utf8()
+                    );
+                    return w.write(nil.as_bytes());
+                }
+
+                return w.write_slice(response.data(), 0);
+
+                log::debug!("+++ ignore non-first rsp for cmd: {:?}", cfg.name);
+                Ok(())
             } else {
                 // 有些请求，如mset，不需要bulk_num,说明只需要返回一个首个key的请求即可。
                 // mset always return +OK

--- a/stream/src/metric.rs
+++ b/stream/src/metric.rs
@@ -46,7 +46,7 @@ macro_rules! define_metrics {
 }
 
 define_metrics!(
-    qps:    tx-tx, rx-rx, err-err, cps-cps, kps-kps, conn-conn,noresponse-noresponse, key-key, hit-hit;
+    qps:    tx-tx, rx-rx, err-err, cps-cps, kps-kps, conn-conn,noresponse-noresponse, key-key, hit-hit, nilconvert-nilconvert;
     num:    conn_num-conn, unsupport_cmd-unsupport_cmd;
     rtt:    avg-avg;
     ratio:  cache-hit

--- a/stream/src/pipeline.rs
+++ b/stream/src/pipeline.rs
@@ -222,7 +222,10 @@ where
             }
 
             if ctx.inited() && !ctx.request().ignore_rsp() {
-                parser.write_response(&mut ctx, client)?;
+                let nil_convert = parser.write_response(&mut ctx, client)?;
+                if nil_convert > 0 {
+                    *metrics.nilconvert() += nil_convert;
+                }
                 ctx.async_start_write_back(parser);
             } else if ctx.request().ignore_rsp() {
                 // do nothing!
@@ -238,7 +241,11 @@ where
                 }
 
                 // 传入top，某些指令需要
-                parser.write_no_response(req, client, |hash| top.shard_idx(hash))?;
+                let nil_convert =
+                    parser.write_no_response(req, client, |hash| top.shard_idx(hash))?;
+                if nil_convert > 0 {
+                    *metrics.nilconvert() += nil_convert;
+                }
             }
 
             // 数据写完，统计耗时。当前数据只写入到buffer中，


### PR DESCRIPTION
1. multi 指令过滤异常信息，发送对应的nil值，并对nilconvert进行统计；（$-1, :-10）  
2. 支持从vintage都去socks列表，并构建socks文件；
3. 对unsupport cmd，进行日志及统计，修复之前的统计异常；  
4. 对init失败、监听、accept失败，都增加ns监听失败的计数。 