### PR TITLE
replace ds::ready to 1.64 std::task::ready which

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@ Dockerfile
 
 .DS_Store
 .idea/*
-
-./breeze.log

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Dockerfile
 **/*.swo
 
 .DS_Store
+.idea/*
+
+./breeze.log

--- a/metrics/src/packet.rs
+++ b/metrics/src/packet.rs
@@ -1,6 +1,6 @@
 use std::task::{Context, Poll};
 
-use ds::ready;
+use std::task::ready;
 use tokio::net::UdpSocket;
 
 #[derive(Default)]

--- a/metrics/src/register.rs
+++ b/metrics/src/register.rs
@@ -208,7 +208,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use ds::ready;
+use std::task::ready;
 use tokio::time::{interval, Interval, MissedTickBehavior};
 
 impl Future for MetricRegister {

--- a/metrics/src/sender.rs
+++ b/metrics/src/sender.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
-use ds::ready;
+use std::task::ready;
 use tokio::time::{interval, Interval, MissedTickBehavior};
 
 pub struct Sender {

--- a/rt/src/entry.rs
+++ b/rt/src/entry.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
-use ds::ready;
+use std::task::ready;
 use metrics::{Metric, Path};
 use tokio::{
     io::{AsyncRead, AsyncWrite},

--- a/rt/src/stream/mod.rs
+++ b/rt/src/stream/mod.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use ds::ready;
+use std::task::ready;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 // 1. read/write统计

--- a/stream/src/handler.rs
+++ b/stream/src/handler.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use ds::chan::mpsc::Receiver;
-use ds::ready;
+use std::task::ready;
 use protocol::{Error, Protocol, Request, Result, Stream, Utf8};
 use tokio::io::{AsyncRead, AsyncWrite};
 

--- a/stream/src/pipeline.rs
+++ b/stream/src/pipeline.rs
@@ -6,7 +6,7 @@ use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
 use ds::AtomicWaker;
-use ds::ready;
+use std::task::ready;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 #[allow(unused_imports)]


### PR DESCRIPTION
将所有依赖的 ds::ready 替换成rust 1.64中的std::task::ready