### PR TITLE
只对range/modrange类dist进行后端数量限制

### DIFF
--- a/endpoint/src/redisservice/config.rs
+++ b/endpoint/src/redisservice/config.rs
@@ -48,9 +48,11 @@ impl RedisNamespace {
             })
             .ok();
         if let Some(ns) = nso {
-            // check backend size，对于非modula/absmodula限制后端数量为2^n
-            let dist = ns.basic.distribution.clone();
-            if dist.ne(DIST_MODULA) && dist.ne(DIST_ABS_MODULA) {
+            // check backend size，对于range/modrange类型的dist需要限制后端数量为2^n
+            let dist = &ns.basic.distribution;
+            if dist.starts_with(sharding::distribution::DIST_RANGE)
+                || dist.starts_with(sharding::distribution::DIST_MOD_RANGE)
+            {
                 let len = ns.backends.len();
                 let power_two = len > 0 && ((len & len - 1) == 0);
                 if !power_two {

--- a/sharding/src/distribution/mod.rs
+++ b/sharding/src/distribution/mod.rs
@@ -31,11 +31,15 @@ pub const DIST_MODULA: &str = "modula";
 pub const DIST_ABS_MODULA: &str = "absmodula";
 pub const DIST_KETAMA: &str = "ketama";
 
+// 默认的range分布策略是range，对应的slot是256，如果slot数是xxx(非256)，则需要设置为：range-xxx，shard 需要是2的n次方
+pub const DIST_RANGE: &str = "range";
+// modrange，用于mod后再分区间, shard 需要是2的n次方
+pub const DIST_MOD_RANGE: &str = "modrange";
+
 // 默认采用的slot是256，slot等价于client的hash-gen概念，即集群的槽（虚拟节点）的总数，
 // 每个redis分片会保存某个范围的slot槽点，多个redis 分片(shard)就组合成一个cluster
 const DIST_RANGE_SLOT_COUNT_DEFAULT: u64 = 256;
-// 默认的range分布策略是range，对应的slot是256，如果slot数是xxx(非256)，则需要设置为：range-xxx
-const DIST_RANGE: &str = "range";
+
 const DIST_RANGE_WITH_SLOT_PREFIX: &str = "range-";
 
 // modrange，用于mod后再分区间


### PR DESCRIPTION
随着dist大量引入，很多dist不需要对后端数量进行限制，调整限制逻辑，当前只对range、modrange及其这两种衍生类型才进行2^n限制。