### PR TITLE
对redis协议解析异常指令增加安全保护

### DIFF
--- a/protocol/src/redis/mod.rs
+++ b/protocol/src/redis/mod.rs
@@ -85,7 +85,7 @@ impl Redis {
                     if cfg.has_val {
                         // 如果client请求异常，此处没有bulk，可能触发异常
                         if !packet.has_bulk() {
-                            return Err(super::Error::ResponseProtocolInvalid);
+                            return Err(RedisError::ReqInvalid.error());
                         }
                         packet.ignore_one_bulk()?;
                     }

--- a/protocol/src/redis/mod.rs
+++ b/protocol/src/redis/mod.rs
@@ -83,6 +83,10 @@ impl Redis {
                     }
 
                     if cfg.has_val {
+                        // 如果client请求异常，此处没有bulk，可能触发异常
+                        if !packet.has_bulk() {
+                            return Err(super::Error::ResponseProtocolInvalid);
+                        }
                         packet.ignore_one_bulk()?;
                     }
                     let kv = packet.take();

--- a/protocol/src/redis/packet.rs
+++ b/protocol/src/redis/packet.rs
@@ -120,12 +120,12 @@ impl<'a, S: crate::Stream> RequestPacket<'a, S> {
             // TODO client 异常协议，直接断连接 (需要统一梳理类似case？)fishermen
             // assert_ne!(self.bulk(), 0);
             if self.bulk() == 0 {
-                return Err(super::Error::ResponseProtocolInvalid);
+                return Err(RedisError::ReqInvalid.error());
             }
 
             // 增加保护，此时op_code必须为0，否则说明之前协议处理没有正常退出
             if self.ctx.op_code != 0 {
-                return Err(super::Error::ResponseProtocolInvalid);
+                return Err(RedisError::ReqInvalid.error());
             }
         }
         Ok(())

--- a/tests/src/hash_test.rs
+++ b/tests/src/hash_test.rs
@@ -30,7 +30,10 @@ mod hash_test {
         let h2 = rand_hasher.hash(&key.as_bytes());
         let h3 = rand_hasher.hash(&key.as_bytes());
         let h4 = rand_hasher.hash(&key.as_bytes());
-        println!("key:{}, random-h1:{}, h2:{}, h3:{}, h4:{}", key, h1, h2, h3, h4);
+        println!(
+            "key:{}, random-h1:{}, h2:{}, h3:{}, h4:{}",
+            key, h1, h2, h3, h4
+        );
 
         let rawsuffix_hahser = Hasher::from("rawsuffix-underscore");
         let key_suffix = 123456789;


### PR DESCRIPTION
当收到multi的异常指令时，如果协议异常，后续指令处理会触发assert失败。  
在协议解析中，先增加若干保护策略（类似问题，需要统一梳理）。