### PR TITLE
修改redis的master指令到标准解析流程

### DIFF
--- a/protocol/src/redis/command.rs
+++ b/protocol/src/redis/command.rs
@@ -248,18 +248,20 @@ pub(super) static SUPPORTED: Commands = {
     // TODO：后续增加新指令时，当multi/need_bulk_num 均为true时，需要在add_support中进行nil转换，避免将err返回到client fishermen
     for c in vec![
         //// meta 指令
+        // name, mname, arity, op, first_key_index, last_key_index, key_step, padding_rsp, multi, noforward, has_key, has_val, need_bulk_num
         //("command", "command" ,   -1, Meta, 0, 0, 0, 1, false, true, false, false, false),
         //("ping", "ping" ,         -1, Meta, 0, 0, 0, 2, false, true, false, false, false),
         //// 不支持select 0以外的请求。所有的select请求直接返回，默认使用db0
         //("select", "select" ,      2, Meta, 0, 0, 0, 1, false, true, false, false, false),
         //("hello", "hello" ,        2, Meta, 0, 0, 0, 4, false, true, false, false, false),
-        //("quit", "quit" ,          2, Meta, 0, 0, 0, 0, false, true, false, false, false),
+        //("quit", "quit" ,          1, Meta, 0, 0, 0, 0, false, true, false, false, false),
         Cmd::new("command").arity(-1).op(Meta).padding(1).nofwd(),
         Cmd::new("ping").arity(-1).op(Meta).padding(2).nofwd(),
         Cmd::new("select").arity(2).op(Meta).padding(1).nofwd(),
         Cmd::new("hello").arity(2).op(Meta).padding(4).nofwd(),
-        Cmd::new("quit").arity(2).op(Meta).nofwd(),
-        Cmd::new("master").arity(2).op(Meta).nofwd().master(),
+        // quit、master的指令token数/arity应该都是1
+        Cmd::new("quit").arity(1).op(Meta).nofwd(),
+        Cmd::new("master").arity(1).op(Meta).nofwd().master().swallow(),
 
         //("get" , "get",            2, Get, 1, 1, 1, 3, false, false, true, false, false),
         Cmd::new("get").arity(2).op(Get).first(1).last(1).step(1).padding(3).key(),

--- a/protocol/src/redis/mod.rs
+++ b/protocol/src/redis/mod.rs
@@ -129,7 +129,7 @@ impl Redis {
         Ok(())
     }
 
-    // 解析待吞噬的cmd，解析后会trim掉吞噬指令，消除吞噬指令的影响，目前swallowed cmds有master、hashkey、hashrandomq这2个，后续还有扩展就在这里加 fishermen
+    // 解析待吞噬的cmd，解析后会trim掉吞噬指令，消除吞噬指令的影响，目前swallowed cmds有master、hashkeyq、hashrandomq这几个，后续还有扩展就在这里加 fishermen
     fn parse_swallow_cmd<S: Stream, H: Hash>(
         &self,
         cfg: &CommandProperties,

--- a/protocol/src/redis/packet.rs
+++ b/protocol/src/redis/packet.rs
@@ -1,9 +1,7 @@
-use crate::{Error, Result};
+use crate::Result;
 use ds::RingSlice;
 
 const CRLF_LEN: usize = b"\r\n".len();
-// 防止client发大小写组合的master，需要忽略master的大小写 fishermen
-const MASTER_CMD: &str = "*1\r\n$6\r\nMASTER\r\n";
 
 // 这个context是用于中multi请求中，同一个multi请求中跨request协调
 // 必须是u64长度的。
@@ -17,11 +15,9 @@ struct RequestContext {
     _ignore: [u8; 2],
 }
 
-// 请求的layer层次
+// 请求的layer层次，目前只有masterOnly，后续支持业务访问某层时，在此扩展属性
 pub enum LayerType {
-    NotChecked = 0,
-    All = 1,
-    MasterOnly = 2,
+    MasterOnly = 1,
 }
 
 impl RequestContext {
@@ -78,39 +74,6 @@ impl<'a, S: crate::Stream> RequestPacket<'a, S> {
         self.oft < self.data.len()
     }
 
-    // 解析访问layer，由于master非独立指令，如果返回Ok，需要确保还有数据可以继续解析
-    // master 过于简单，先直接解析处理，后续可以加到swallowed cmd中
-    #[inline]
-    pub(super) fn parse_cmd_layer(&mut self) -> Result<bool> {
-        if !self.layer_checked() {
-            match self
-                .data
-                .start_with_ignore_case(self.oft, MASTER_CMD.as_bytes())
-            {
-                Ok(rs) => {
-                    if rs {
-                        self.oft += MASTER_CMD.len();
-                        self.oft_last = self.oft;
-                        self.stream.ignore(MASTER_CMD.len());
-                        self.set_layer(LayerType::MasterOnly);
-
-                        // master 不是独立指令，只有还有数据可解析时，才返回Ok，否则协议不完整 fishermen
-                        if self.available() {
-                            return Ok(true);
-                        }
-                        return Err(Error::ProtocolIncomplete);
-                    } else {
-                        self.set_layer(LayerType::All);
-                        return Ok(false);
-                    }
-                }
-                // 只有长度不够才会返回err
-                Err(_) => return Err(Error::ProtocolIncomplete),
-            };
-        }
-        // 之前已经check过，直接取
-        Ok(self.master_only())
-    }
     #[inline]
     pub(super) fn parse_bulk_num(&mut self) -> Result<()> {
         if self.bulk() == 0 {
@@ -173,11 +136,13 @@ impl<'a, S: crate::Stream> RequestPacket<'a, S> {
     // 重置context，包括stream中的context
     #[inline]
     fn reset_context(&mut self) {
+        // 重置packet的ctx
         self.ctx.reset();
-        assert_eq!(self.ctx.u64(), 0, "packet:{}", self);
 
-        // 重置context
+        // 重置stream的ctx
         *self.stream.context() = 0;
+
+        assert_eq!(self.ctx.u64(), 0, "packet:{}", self);
     }
 
     // 重置reserved hash，包括stream中的对应值
@@ -216,18 +181,28 @@ impl<'a, S: crate::Stream> RequestPacket<'a, S> {
     // trim掉已解析的cmd相关元数据，只保留在master_only、reserved_hash这两个元数据
     #[inline]
     pub(super) fn trim_swallowed_cmd(&mut self) -> Result<()> {
+        // trim 吞噬指令时，整个吞噬指令必须已经被解析完毕
+        debug_assert!(self.ctx.bulk == 0, "packet:{}", self);
+
+        // 移动oft到吞噬指令之后
         let len = self.oft - self.oft_last;
         self.oft_last = self.oft;
         self.stream.ignore(len);
 
-        debug_assert!(self.ctx.bulk == 0, "packet:{}", self);
-        // 重置context，下一个指令重新解析，注意：master_only要保留
+        // 记录需保留的状态：目前只有master only状态【direct hash保存在stream的非ctx字段中】
         let master_only = self.master_only();
+
+        // 重置context，去掉packet/stream的ctx信息
         self.reset_context();
+
+        // 保留后续cmd执行需要的状态：当前只有master
         if master_only {
             // 保留master only 设置
             self.set_layer(LayerType::MasterOnly);
         }
+
+        // 设置packet的ctx到stream的ctx中，供下一个指令使用
+        *self.stream.context() = self.ctx.u64();
 
         if self.available() {
             return Ok(());
@@ -270,13 +245,8 @@ impl<'a, S: crate::Stream> RequestPacket<'a, S> {
         &self.data
     }
     #[inline]
-    pub fn layer_checked(&self) -> bool {
-        self.ctx.layer != (LayerType::NotChecked as u8)
-    }
-    #[inline]
     pub(super) fn set_layer(&mut self, layer: LayerType) {
         self.ctx.layer = layer as u8;
-        *self.stream.context() = self.ctx.u64();
     }
     #[inline]
     pub(super) fn master_only(&self) -> bool {


### PR DESCRIPTION
当前redis cmd新模式增加了master_next属性，故将master指令改用标准解析流程，更方便快捷。