### PR TITLE
修复请求异常及geo指令路由问题

### DIFF
--- a/ds/src/mem/ring_slice.rs
+++ b/ds/src/mem/ring_slice.rs
@@ -313,14 +313,16 @@ impl Debug for RingSlice {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use crate::Utf8;
+        let data = if self.len() > 1024 {
+            format!("[hidden for too long len:{}]", self.len())
+        } else {
+            self.to_vec().utf8()
+        };
+
         write!(
             f,
             "ptr:{} start:{} end:{} cap:{} => {:?}",
-            self.ptr,
-            self.start,
-            self.end,
-            self.cap,
-            self.to_vec().utf8()
+            self.ptr, self.start, self.end, self.cap, data
         )
     }
 }

--- a/protocol/src/error.rs
+++ b/protocol/src/error.rs
@@ -70,4 +70,12 @@ impl Error {
             _ => false,
         }
     }
+
+    // 对于网络IO异常，一般需要立即关闭连接
+    pub fn io_err(&self) -> bool {
+        match self {
+            Self::IO(_) => true,
+            _ => false,
+        }
+    }
 }

--- a/protocol/src/msgque/mcq/text/rsppacket.rs
+++ b/protocol/src/msgque/mcq/text/rsppacket.rs
@@ -262,10 +262,6 @@ impl<'a, S: crate::Stream> RspPacket<'a, S> {
         Err(super::Error::ProtocolIncomplete)
     }
 
-    pub(super) fn is_empty(&self) -> bool {
-        self.rsp_type == RspType::End
-    }
-
     #[inline]
     pub(super) fn take(&mut self) -> ds::MemGuard {
         assert!(

--- a/protocol/src/redis/command.rs
+++ b/protocol/src/redis/command.rs
@@ -502,14 +502,14 @@ pub(super) static SUPPORTED: Commands = {
 
         // geo 相关指令
         //("geoadd", "geoadd",                       -5, Store, 1, 1, 1, 3, false, false, true, true, false),
-        //("georadius", "georadius",                 -6, Get, 1, 1, 1, 3, false, false, true, false, false),
-        //("georadiusbymember", "georadiusbymember", -5, Get, 1, 1, 1, 3, false, false, true, false, false),
+        //("georadius", "georadius",                 -6, Store, 1, 1, 1, 3, false, false, true, false, false),
+        //("georadiusbymember", "georadiusbymember", -5, Store, 1, 1, 1, 3, false, false, true, false, false),
         //("geohash", "geohash",                     -2, Get, 1, 1, 1, 3, false, false, true, false, false),
         //("geopos", "geopos",                       -2, Get, 1, 1, 1, 3, false, false, true, false, false),
         //("geodist", "geodist",                     -4, Get, 1, 1, 1, 3, false, false, true, false, false),
         Cmd::new("geoadd").arity(-5).op(Store).first(1).last(1).step(1).padding(3).key().val(),
-        Cmd::new("georadius").arity(-6).op(Get).first(1).last(1).step(1).padding(3).key(),
-        Cmd::new("georadiusbymember").arity(-5).op(Get).first(1).last(1).step(1).padding(3).key(),
+        Cmd::new("georadius").arity(-6).op(Store).first(1).last(1).step(1).padding(3).key(),
+        Cmd::new("georadiusbymember").arity(-5).op(Store).first(1).last(1).step(1).padding(3).key(),
         Cmd::new("geohash").arity(-2).op(Get).first(1).last(1).step(1).padding(3).key(),
         Cmd::new("geopos").arity(-2).op(Get).first(1).last(1).step(1).padding(3).key(),
         Cmd::new("geodist").arity(-4).op(Get).first(1).last(1).step(1).padding(3).key(),

--- a/protocol/src/redis/command.rs
+++ b/protocol/src/redis/command.rs
@@ -269,12 +269,13 @@ pub(super) static SUPPORTED: Commands = {
         //("ping", "ping" ,         -1, Meta, 0, 0, 0, 2, false, true, false, false, false),
         //// 不支持select 0以外的请求。所有的select请求直接返回，默认使用db0
         //("select", "select" ,      2, Meta, 0, 0, 0, 1, false, true, false, false, false),
-        //("hello", "hello" ,        2, Meta, 0, 0, 0, 4, false, true, false, false, false),
+        //("hello", "hello" ,        -1, Meta, 0, 0, 0, 4, false, true, false, false, false),
         //("quit", "quit" ,          1, Meta, 0, 0, 0, 0, false, true, false, false, false),
+        // hello 参数应该是-1，可以不带或者带多个
         Cmd::new("command").arity(-1).op(Meta).padding(1).nofwd(),
         Cmd::new("ping").arity(-1).op(Meta).padding(2).nofwd(),
         Cmd::new("select").arity(2).op(Meta).padding(1).nofwd(),
-        Cmd::new("hello").arity(2).op(Meta).padding(4).nofwd(),
+        Cmd::new("hello").arity(-1).op(Meta).padding(4).nofwd(),
         // quit、master的指令token数/arity应该都是1
         Cmd::new("quit").arity(1).op(Meta).nofwd(),
         Cmd::new("master").arity(1).op(Meta).nofwd().master().swallow(),

--- a/stream/src/buffer.rs
+++ b/stream/src/buffer.rs
@@ -45,7 +45,8 @@ where
         let out = Pin::new(&mut **client).poll_read(cx, &mut rb);
         let r = rb.capacity() - rb.remaining();
         if r > 0 {
-            log::debug!("{} bytes received ==> {:?}", r, &buf[0..r]);
+            // log::debug!("{} bytes received ==> {:?}", r, &buf[0..r]);
+            log::debug!("{} bytes received", r);
         }
         *n += r;
 

--- a/stream/src/checker.rs
+++ b/stream/src/checker.rs
@@ -71,9 +71,9 @@ impl<P, Req> BackendChecker<P, Req> {
                 match e {
                     Error::Timeout(_t) => {
                         m_timeout += 1;
-                        log::info!("{:?} timeout: {:?}", path_addr, _t);
+                        log::info!("backend/{:?} timeout: {:?}", path_addr, _t);
                     }
-                    _ => log::info!("{:?} error: {:?}", path_addr, e),
+                    _ => log::info!("backend/{:?} error: {:?}", path_addr, e),
                 }
             }
         }

--- a/stream/src/reconn.rs
+++ b/stream/src/reconn.rs
@@ -6,7 +6,7 @@ pub(crate) struct ReconnPolicy {
     single: Arc<AtomicBool>,
     conns: usize,
     metric: Metric,
-    errs: u8,
+    continue_fails: usize,
 }
 
 impl ReconnPolicy {
@@ -15,30 +15,70 @@ impl ReconnPolicy {
             single,
             metric: path.status("reconn"),
             conns: 0,
-            errs: 0,
+            continue_fails: 0,
         }
     }
-    pub fn success(&mut self) {
-        self.errs = 0;
-    }
-    // 第一次，不处理。
-    pub async fn check(&mut self) {
-        self.conns += 1;
-        if self.conns == 1 {
-            return;
-        }
-        self.errs = self.errs.wrapping_add(1);
+    // pub fn success(&mut self) {
+    //     self.errs = 0;
+    // }
+    // 连接失败，为下一次连接做准备：sleep一段时间，避免无意义的重连
+    pub async fn conn_failed(&mut self) {
+        // TODO： 测试review完毕，删除 fishermen
+        // self.conns += 1;
+        // if self.conns == 1 {
+        //     return;
+        // }
+        // self.errs = self.errs.wrapping_add(1);
         self.metric += 1;
-        let sleep = if self.single.load(Acquire) {
-            Duration::from_millis(100)
-        } else {
-            Duration::from_millis(3 * 1000)
+        self.continue_fails += 1;
+
+        static MAX_FAILED: usize = 3;
+        let mut sleep_mills = 0;
+        if self.continue_fails >= MAX_FAILED {
+            // 连续失败超过3次，master sleep 100ms，slave sleep 3000
+            if self.single.load(Acquire) {
+                sleep_mills = 100;
+            } else {
+                sleep_mills = 3 * 1000;
+            }
         };
-        if self.errs == 1 {
-            log::info!("{}-th conn {} sleep:{:?} ", self.conns, self.metric, sleep);
+        // TODO： 测试review完毕，删除 fishermen
+        // let sleep = if self.single.load(Acquire) {
+        //     let mills = if self.continue_fails < MAX_FAILED {
+        //         0
+        //     } else {
+        //         100
+        //     };
+        //     Duration::from_millis(mills)
+        // } else {
+        //     let mills = if self.continue_fails < MAX_FAILED {
+        //         0
+        //     } else {
+        //         3 * 1000
+        //     };
+        //     Duration::from_millis(mills)
+        // };
+        if self.continue_fails == 1 {
+            log::info!(
+                "{}-th conn {} sleep:{} ",
+                self.conns,
+                self.continue_fails,
+                sleep_mills
+            );
         } else {
-            log::debug!("{}-th conn {} sleep:{:?} ", self.conns, self.metric, sleep);
+            log::debug!(
+                "{}-th conn {} sleep:{} ",
+                self.conns,
+                self.continue_fails,
+                sleep_mills
+            );
         }
-        tokio::time::sleep(sleep).await;
+        tokio::time::sleep(Duration::from_millis(sleep_mills)).await;
+    }
+
+    // 连接创建成功，连接次数加1，重置持续失败次数
+    pub fn connected(&mut self) {
+        self.conns += 1;
+        self.continue_fails = 0;
     }
 }

--- a/stream/src/reconn.rs
+++ b/stream/src/reconn.rs
@@ -18,46 +18,23 @@ impl ReconnPolicy {
             continue_fails: 0,
         }
     }
-    // pub fn success(&mut self) {
-    //     self.errs = 0;
-    // }
+
     // 连接失败，为下一次连接做准备：sleep一段时间，避免无意义的重连
     pub async fn conn_failed(&mut self) {
-        // TODO： 测试review完毕，删除 fishermen
-        // self.conns += 1;
-        // if self.conns == 1 {
-        //     return;
-        // }
-        // self.errs = self.errs.wrapping_add(1);
         self.metric += 1;
         self.continue_fails += 1;
 
-        static MAX_FAILED: usize = 3;
+        static MAX_FAILED: usize = 1;
         let mut sleep_mills = 0;
         if self.continue_fails >= MAX_FAILED {
-            // 连续失败超过3次，master sleep 100ms，slave sleep 3000
+            // 连续失败超过$MAX_FAILED次，master sleep 100ms，slave sleep 3000
             if self.single.load(Acquire) {
                 sleep_mills = 100;
             } else {
                 sleep_mills = 3 * 1000;
             }
         };
-        // TODO： 测试review完毕，删除 fishermen
-        // let sleep = if self.single.load(Acquire) {
-        //     let mills = if self.continue_fails < MAX_FAILED {
-        //         0
-        //     } else {
-        //         100
-        //     };
-        //     Duration::from_millis(mills)
-        // } else {
-        //     let mills = if self.continue_fails < MAX_FAILED {
-        //         0
-        //     } else {
-        //         3 * 1000
-        //     };
-        //     Duration::from_millis(mills)
-        // };
+
         if self.continue_fails == 1 {
             log::info!(
                 "{}-th conn {} sleep:{} ",


### PR DESCRIPTION
1 请求遇到网络异常不再等待，立即返回异常；
2 geo两个指令：georadiusCommand、georadiusbymemberCommand，从get调整为store类型；
3 调整hello参数个数（为啥返回Err？）
4 调整重连策略，避免超时等异常后failfast。