### PR TITLE
连接失败时，也修改ReconnPolicy的conn计数

### DIFF
--- a/stream/src/reconn.rs
+++ b/stream/src/reconn.rs
@@ -21,6 +21,7 @@ impl ReconnPolicy {
 
     // 连接失败，为下一次连接做准备：sleep一段时间，避免无意义的重连
     pub async fn conn_failed(&mut self) {
+        self.conns += 1;
         self.metric += 1;
         self.continue_fails += 1;
 


### PR DESCRIPTION
连接失败时，也修改ReconnPolicy的conn计数，这样方便日志记录查看