### PR TITLE
恢复功能：socklist从vintage获取

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -12,8 +12,8 @@ mod service;
 use discovery::*;
 mod init;
 
-use rt::spawn;
 use ds::time::Duration;
+use rt::spawn;
 
 use protocol::Result;
 
@@ -39,10 +39,20 @@ async fn run() -> Result<()> {
     let snapshot = ctx.snapshot_path.to_string();
     let tick = ctx.tick();
     let mut fix = discovery::Fixed::default();
-    fix.register(
-        ctx.idc_path.to_string(),
-        discovery::distance::build_refresh_idc(),
-    );
+    fix.register(ctx.idc_path_url(), discovery::distance::build_refresh_idc());
+
+    // 从vintage获取socks
+    if ctx.service_pool_socks_url().len() > 1 {
+        fix.register(
+            ctx.service_pool_socks_url(),
+            discovery::socks::build_refresh_socks(ctx.service_path.clone()),
+        );
+    } else {
+        log::info!(
+            "only use socks from local path: {}",
+            ctx.service_path.clone()
+        );
+    }
 
     rt::spawn(watch_discovery(snapshot, discovery, rx, tick, fix));
     log::info!("server inited {:?}", ctx);

--- a/context/src/lib.rs
+++ b/context/src/lib.rs
@@ -31,13 +31,24 @@ pub struct ContextOption {
     )]
     pub discovery: Url,
 
+    // 用于设置url的统一前缀，从而减少配置参数的长度，用途：
+    //    1 和service_pool整合，可构建基于vintage拉取sock file的url；
+    //    2 和idc_path整合，可以作为完整的idc path url
+    #[clap(
+        long,
+        help("registry url prefix. e.g. static.config.xxx.xxx"),
+        default_value("")
+    )]
+    url_prefix: String,
+
+    // 需要兼容url_prefix不设置的场景，故去掉pub属性
     #[clap(
         short,
         long,
         help("idc config path"),
         default_value("/3/config/breeze/idc_region")
     )]
-    pub idc_path: String,
+    idc_path: String,
 
     #[clap(
         long,
@@ -144,6 +155,24 @@ impl ContextOption {
             path: self.service_path.to_string(),
             processed: Default::default(),
         }
+    }
+
+    // 兼容策略：如果idc不包含url_prefix加上该前缀；否则直接返回;
+    pub fn idc_path_url(&self) -> String {
+        // idc-path参数
+        if self.url_prefix.len() > 0 && !self.idc_path.contains(&self.url_prefix.to_string()) {
+            return format!("{}/{}", self.url_prefix, self.idc_path);
+        }
+        self.idc_path.clone()
+    }
+
+    // 根据url_prefix和service_pool 构建 服务池socks url
+    pub fn service_pool_socks_url(&self) -> String {
+        if self.url_prefix.len() > 0 {
+            let socks_path = "3/config/datamesh/config";
+            return format!("{}/{}/{}", self.url_prefix, socks_path, self.service_pool);
+        }
+        Default::default()
     }
 }
 

--- a/context/src/lib.rs
+++ b/context/src/lib.rs
@@ -88,7 +88,7 @@ pub struct ContextOption {
     )]
     pub metrics_probe: String,
 
-    #[clap(long, help("log level. debug|info|warn|error"), default_value("info"))]
+    #[clap(long, help("log level. debug|info|warn|error"), default_value("error"))]
     pub log_level: String,
 
     #[clap(long, help("service pool"), default_value("default_pool"))]

--- a/stream/src/pipeline.rs
+++ b/stream/src/pipeline.rs
@@ -1,3 +1,4 @@
+use ds::time::{Duration, Instant};
 use std::collections::VecDeque;
 use std::future::Future;
 use std::pin::Pin;
@@ -6,7 +7,6 @@ use std::sync::{
     Arc,
 };
 use std::task::{ready, Context, Poll};
-use ds::time::{Duration, Instant};
 
 use tokio::io::{AsyncRead, AsyncWrite};
 


### PR DESCRIPTION
socklist的部分代码在merge中丢失，恢复支持。  
策略说明：如果按服务池在vintage设置socklist，则以vintage为准。即：本地多余的sock会被清理，缺少的socks会被补上。  