### PR TITLE
修改response的处理逻辑

### DIFF
--- a/ds/src/mem/guarded.rs
+++ b/ds/src/mem/guarded.rs
@@ -131,8 +131,7 @@ impl MemGuard {
     pub fn from_vec(data: Vec<u8>) -> Self {
         let mem: RingSlice = data.as_slice().into();
         //assert_eq!(data.capacity(), mem.len());
-        // mc某些特殊请求，如quit、getq，data长度可能为0
-        // assert_ne!(data.len(), 0);
+        assert_ne!(data.len(), 0);
         let cap = data.capacity();
         let _ = std::mem::ManuallyDrop::new(data);
         let guard = 0 as *const _;

--- a/ds/src/mem/ring_slice.rs
+++ b/ds/src/mem/ring_slice.rs
@@ -270,7 +270,8 @@ impl Debug for RingSlice {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use crate::Utf8;
         let slice = self.sub_slice(0, 512.min(self.len()));
-        let data = Vec::with_capacity(slice.len());
+        let mut data = Vec::with_capacity(slice.len());
+        slice.copy_to_vec(&mut data);
         write!(
             f,
             "ptr:{} start:{} len:{} cap:{} => {:?}",

--- a/protocol/src/callback.rs
+++ b/protocol/src/callback.rs
@@ -101,17 +101,17 @@ impl CallbackContext {
     }
 
     #[inline]
-    pub fn take_response_or<F: Fn(&Self) -> Command>(&mut self, f: F) -> Command {
+    pub fn take_response(&mut self) -> Option<Command> {
         match self
             .ctx
             .inited
             .compare_exchange(true, false, AcqRel, Acquire)
         {
-            Ok(_) => unsafe { ptr::read(self.response.as_mut_ptr()) },
+            Ok(_) => unsafe { Some(ptr::read(self.response.as_mut_ptr())) },
             Err(_) => {
                 self.ctx.write_back = false;
                 //assert!(!self.ctx.try_next && !self.ctx.write_back, "{}", self);
-                f(self)
+                None
             }
         }
     }

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -99,18 +99,18 @@ impl Protocol for MemcacheBinary {
         ctx: &mut C,
         w: &mut W,
     ) -> Result<()> {
+        // sendonly 直接返回
+        if ctx.request().sentonly() {
+            assert!(ctx.response().is_none(), "req:{:?}", ctx.request());
+            return Ok(());
+        }
+
         // 如果原始请求是quite_get请求，并且not found，则不回写。
         let old_op_code = ctx.request().op_code();
-        // let response = ctx.response_mut();
-        // 如果原始请求是quite_get请求，并且not found，则不回写。
 
+        // 如果原始请求是quite_get请求，并且not found，则不回写。
         if let Some(rsp) = ctx.response_mut() {
-            // debug_assert!(
-            //     !ctx.request().sentonly() && rsp.data().len() > 0,
-            //     "mc req:{:?}, rsp:{:?}",
-            //     ctx.request(),
-            //     rsp
-            // );
+            assert!(rsp.data().len() > 0, "empty rsp:{:?}", rsp);
 
             // 如果quite 请求没拿到数据，直接忽略
             if QUITE_GET_TABLE[old_op_code as usize] == 1 && !rsp.ok() {

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -3,7 +3,7 @@ mod packet;
 
 use packet::*;
 
-use crate::{Error, Flag, Metric, MetricName, Result, Stream};
+use crate::{Error, Flag, MetricName, Result, Stream};
 
 #[derive(Clone, Default)]
 pub struct MemcacheBinary;
@@ -378,7 +378,7 @@ impl MemcacheBinary {
 
     // 当前只统计缓存命中率，后续需要其他统计，在此增加
     #[inline(always)]
-    fn metrics<M: crate::Metric<T>, T: std::ops::AddAssign<i64>>(
+    fn metrics<M: crate::Metric<T>, T: std::ops::AddAssign<i64> + std::ops::AddAssign<bool>>(
         &self,
         request: &HashedCommand,
         response: Option<&Command>,

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -90,29 +90,80 @@ impl Protocol for MemcacheBinary {
     }
     // 在parse_request中可能会更新op_code，在write_response时，再更新回来。
     #[inline]
-    fn write_response<C: crate::Commander, W: crate::Writer>(
+    fn write_response<W: crate::Writer, F: Fn(i64) -> usize>(
         &self,
-        ctx: &mut C,
+        request: &HashedCommand,
+        response: &mut Option<Command>,
+        _dist_fn: F,
         w: &mut W,
     ) -> Result<()> {
         // 如果原始请求是quite_get请求，并且not found，则不回写。
-        let old_op_code = ctx.request().op_code();
-        let resp = ctx.response_mut();
-        if (QUITE_GET_TABLE[old_op_code as usize] == 1 && !resp.ok()) || resp.data().len() == 0 {
+
+        if let Some(rsp) = response {
+            debug_assert!(rsp.data().len() > 0, "mc req:{:?}, rsp:{:?}", request, rsp);
+            debug_assert!(!request.sentonly(), "mc req:{:?}, rsp:{:?}", request, rsp);
+
+            let old_op_code = request.op_code();
+            // 如果quite 请求没拿到数据，直接忽略
+            if QUITE_GET_TABLE[old_op_code as usize] == 1 && !rsp.ok() {
+                return Ok(());
+            }
+            log::debug!("+++ will write mc rsp:{:?}", rsp.data());
+            let data = rsp.data_mut();
+            data.restore_op(old_op_code as u8);
+            w.write_slice(data, 0)?;
             return Ok(());
         }
-        log::debug!("+++ will write mc rsp:{:?}", resp.data());
-        let data = resp.data_mut();
-        data.restore_op(old_op_code as u8);
-        w.write_slice(data, 0)?;
+
+        match request.op_code() as u8 {
+            // noop: 第一个字节变更为Response，其他的与Request保持一致
+            OP_CODE_NOOP => {
+                w.write_u8(RESPONSE_MAGIC)?;
+                w.write_slice(request.data(), 1)?;
+            }
+
+            //version: 返回固定rsp
+            OP_CODE_VERSION => w.write(&VERSION_RESPONSE)?,
+
+            // stat：返回固定rsp
+            OP_CODE_STAT => w.write(&STAT_RESPONSE)?,
+
+            // quit/quitq 无需返回rsp
+            OP_CODE_QUIT | OP_CODE_QUITQ => return Err(Error::Quit),
+
+            // quite get 请求，无需返回任何rsp，但没实际发送，rsp_ok设为false
+            OP_CODE_GETQ | OP_CODE_GETKQ => return Ok(()),
+            // 0x09 | 0x0d => return Ok(()),
+
+            // set: mc status设为 Item Not Stored,status设为false
+            OP_CODE_SET => w.write(&self.build_empty_response(RespStatus::NotStored, request))?,
+            // self.build_empty_response(RespStatus::NotStored, req)
+
+            // get，返回key not found 对应的0x1
+            OP_CODE_GET => w.write(&self.build_empty_response(RespStatus::NotFound, request))?,
+            // self.build_empty_response(RespStatus::NotFound, req)
+
+            // TODO：之前是直接mesh断连接，现在返回异常rsp，由client决定应对，观察副作用 fishermen
+            _ => return Err(Error::NoResponseFound),
+        }
+        Ok(())
+
+        // if (QUITE_GET_TABLE[old_op_code as usize] == 1 && !resp.ok()) || resp.data().len() == 0 {
+        //     return Ok(());
+        // }
+        // log::debug!("+++ will write mc rsp:{:?}", resp.data());
+        // let data = resp.data_mut();
+        // data.restore_op(old_op_code as u8);
+        // w.write_slice(data, 0)?;
 
         // 对于quit，直接返回error断连，其他正常返回
-        match old_op_code {
-            // TODO: opcode按协议应该是u8，当前是u16，此处继续沿用数字，后续统一重构 fishermen
-            0x07 | 0x17 => Err(Error::Quit),
-            _ => Ok(()),
-        }
+        // match old_op_code {
+        //     // TODO: opcode按协议应该是u8，当前是u16，此处继续沿用数字，后续统一重构 fishermen
+        //     0x07 | 0x17 => Err(Error::Quit),
+        //     _ => Ok(()),
+        // }
     }
+
     // 如果是写请求，把cas请求转换为set请求。
     // 如果是读请求，则通过response重新构建一个新的写请求。
     #[inline]
@@ -135,75 +186,75 @@ impl Protocol for MemcacheBinary {
     //  1 对于hashkey、keyshard直接构建resp；
     //  2 对于除keyshard外的multi+ need bulk num 的 req，构建nil rsp；(注意keyshard是mulit+多bulk)
     //  2 对其他固定响应的请求，构建padding rsp；
-    fn build_local_response<F: Fn(i64) -> usize>(
-        &self,
-        req: &HashedCommand,
-        _dist_fn: F,
-    ) -> Command {
-        if req.sentonly() {
-            let mut rsp = Command::from_vec(Vec::with_capacity(0));
-            rsp.set_status_ok(true);
-            return rsp;
-        }
+    // fn build_local_response<F: Fn(i64) -> usize>(
+    //     &self,
+    //     req: &HashedCommand,
+    //     _dist_fn: F,
+    // ) -> Command {
+    //     if req.sentonly() {
+    //         let mut rsp = Command::from_vec(Vec::with_capacity(0));
+    //         rsp.set_status_ok(true);
+    //         return rsp;
+    //     }
 
-        let mut resp_ok = true;
-        let resp_data = match req.op_code() as u8 {
-            // noop: 第一个字节变更为Response，其他的与Request保持一致
-            OP_CODE_NOOP => {
-                let mut rsp_noop = Vec::with_capacity(req.data().len());
-                req.data().copy_to_vec(&mut rsp_noop);
-                rsp_noop[0] = RESPONSE_MAGIC;
-                rsp_noop
-                // w.write_u8(RESPONSE_MAGIC)?;
-                // w.write_slice(req.data(), 1)?;
-                // Ok(0)
-            }
+    //     let mut resp_ok = true;
+    //     let resp_data = match req.op_code() as u8 {
+    //         // noop: 第一个字节变更为Response，其他的与Request保持一致
+    //         OP_CODE_NOOP => {
+    //             let mut rsp_noop = Vec::with_capacity(req.data().len());
+    //             req.data().copy_to_vec(&mut rsp_noop);
+    //             rsp_noop[0] = RESPONSE_MAGIC;
+    //             rsp_noop
+    //             // w.write_u8(RESPONSE_MAGIC)?;
+    //             // w.write_slice(req.data(), 1)?;
+    //             // Ok(0)
+    //         }
 
-            //version: 返回固定rsp
-            OP_CODE_VERSION => Vec::from(VERSION_RESPONSE),
-            // w.write(&VERSION_RESPONSE)?;
-            // Ok(0)
+    //         //version: 返回固定rsp
+    //         OP_CODE_VERSION => Vec::from(VERSION_RESPONSE),
+    //         // w.write(&VERSION_RESPONSE)?;
+    //         // Ok(0)
 
-            // stat：返回固定rsp
-            OP_CODE_STAT => Vec::from(STAT_RESPONSE),
-            // w.write(&STAT_RESPONSE)?;
-            // Ok(0)
+    //         // stat：返回固定rsp
+    //         OP_CODE_STAT => Vec::from(STAT_RESPONSE),
+    //         // w.write(&STAT_RESPONSE)?;
+    //         // Ok(0)
 
-            // quit/quitq 无需返回rsp
-            OP_CODE_QUIT | OP_CODE_QUITQ => Vec::with_capacity(0),
+    //         // quit/quitq 无需返回rsp
+    //         OP_CODE_QUIT | OP_CODE_QUITQ => Vec::with_capacity(0),
 
-            // quite get 请求，无需返回任何rsp，但没实际发送，rsp_ok设为false
-            0x09 | 0x0d => {
-                resp_ok = false;
-                Vec::with_capacity(0) // Ok(0),
-            }
-            // set: mc status设为 Item Not Stored,status设为false
-            0x01 => {
-                resp_ok = false;
-                self.build_empty_response(RespStatus::NotStored, req)
-                // w.write(&self.build_empty_response(0x5, req.data()))?;
-                // Ok(0)
-            }
+    //         // quite get 请求，无需返回任何rsp，但没实际发送，rsp_ok设为false
+    //         0x09 | 0x0d => {
+    //             resp_ok = false;
+    //             Vec::with_capacity(0) // Ok(0),
+    //         }
+    //         // set: mc status设为 Item Not Stored,status设为false
+    //         0x01 => {
+    //             resp_ok = false;
+    //             self.build_empty_response(RespStatus::NotStored, req)
+    //             // w.write(&self.build_empty_response(0x5, req.data()))?;
+    //             // Ok(0)
+    //         }
 
-            // get，返回key not found 对应的0x1
-            0x00 => {
-                resp_ok = false;
-                self.build_empty_response(RespStatus::NotFound, req)
-                // w.write(&self.build_empty_response(0x1, req.data()))?;
-                // Ok(0)
-            }
+    //         // get，返回key not found 对应的0x1
+    //         0x00 => {
+    //             resp_ok = false;
+    //             self.build_empty_response(RespStatus::NotFound, req)
+    //             // w.write(&self.build_empty_response(0x1, req.data()))?;
+    //             // Ok(0)
+    //         }
 
-            // TODO：之前是直接mesh断连接，现在返回异常rsp，由client决定应对，观察副作用 fishermen
-            _ => {
-                resp_ok = false;
-                log::warn!("+++ found unsupported local rsp for mc req:{:?}", req);
-                self.build_empty_response(RespStatus::InvalidArg, req)
-            }
-        };
-        let mut req = Command::from_vec(resp_data);
-        req.set_status_ok(resp_ok);
-        req
-    }
+    //         // TODO：之前是直接mesh断连接，现在返回异常rsp，由client决定应对，观察副作用 fishermen
+    //         _ => {
+    //             resp_ok = false;
+    //             log::warn!("+++ found unsupported local rsp for mc req:{:?}", req);
+    //             self.build_empty_response(RespStatus::InvalidArg, req)
+    //         }
+    //     };
+    //     let mut req = Command::from_vec(resp_data);
+    //     req.set_status_ok(resp_ok);
+    //     req
+    // }
 
     // TODO 暂时保留，备查及比对，待上线稳定一段时间后再删除（预计 2022.12.30之后可以） fishermen
     // #[inline]
@@ -250,7 +301,7 @@ impl Protocol for MemcacheBinary {
 impl MemcacheBinary {
     // 根据req构建response，status为mc协议status，共11种
     #[inline]
-    fn build_empty_response(&self, status: RespStatus, req: &HashedCommand) -> Vec<u8> {
+    fn build_empty_response(&self, status: RespStatus, req: &HashedCommand) -> [u8; HEADER_LEN] {
         let req_slice = req.data();
         let mut response = [0; HEADER_LEN];
         response[PacketPos::Magic as usize] = RESPONSE_MAGIC;
@@ -260,7 +311,7 @@ impl MemcacheBinary {
         for i in PacketPos::Opaque as usize..PacketPos::Opaque as usize + 4 {
             response[i] = req_slice.at(i);
         }
-        Vec::from(response)
+        response
     }
     #[inline]
     fn build_write_back_inplace(&self, req: &mut HashedCommand) {

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -386,9 +386,10 @@ impl MemcacheBinary {
     ) {
         if request.operation().is_query() {
             if let Some(rsp) = response {
-                *metrics.get(MetricName::Cache) += rsp.ok() as i64;
+                *metrics.get(MetricName::Cache) += rsp.ok();
             } else {
-                *metrics.get(MetricName::Cache) += 0
+                // 没有response的query，作为miss
+                *metrics.get(MetricName::Cache) += false;
             }
         }
     }

--- a/protocol/src/memcache/binary/packet.rs
+++ b/protocol/src/memcache/binary/packet.rs
@@ -111,20 +111,22 @@ const TRY_NEXT_TABLE: [u8; 128] = [
 
 pub(super) const REQUEST_MAGIC: u8 = 0x80;
 pub(super) const RESPONSE_MAGIC: u8 = 0x81;
-//pub(super) const OP_CODE_GET: u8 = 0x00;
+pub(super) const OP_CODE_GET: u8 = 0x00;
 pub(super) const OP_CODE_NOOP: u8 = 0x0a;
 pub(super) const OP_CODE_VERSION: u8 = 0x0b;
 pub(super) const OP_CODE_STAT: u8 = 0x10;
 pub(super) const OP_CODE_QUIT: u8 = 0x07;
 pub(super) const OP_CODE_QUITQ: u8 = 0x17;
+pub(super) const OP_CODE_GETKQ: u8 = 0x0d;
+pub(super) const OP_CODE_GETQ: u8 = 0x09;
+pub(super) const OP_CODE_SET: u8 = 0x01;
+
 //pub(super) const OP_CODE_GETK: u8 = 0x0c;
-//pub(super) const OP_CODE_GETKQ: u8 = 0x0d;
-//pub(super) const OP_CODE_GETQ: u8 = 0x09;
+
 // 这个专门为gets扩展
 //pub(super) const OP_CODE_GETS: u8 = 0x48;
 //pub(super) const OP_CODE_GETSQ: u8 = 0x49;
 
-//pub(super) const OP_CODE_SET: u8 = 0x01;
 //pub(super) const OP_CODE_ADD: u8 = 0x02;
 //pub(super) const OP_CODE_DEL: u8 = 0x04;
 

--- a/protocol/src/msgque/mcq/text/command.rs
+++ b/protocol/src/msgque/mcq/text/command.rs
@@ -40,9 +40,7 @@ impl CommandProperties {
     #[inline(always)]
     pub(super) fn get_padding_rsp(&self) -> &str {
         // 注意：quit的padding rsp为0
-        *PADDING_RSP_TABLE
-            .get(self.padding_rsp)
-            .expect(format!("cmd:{}/{}", self.name, self.padding_rsp).as_str())
+        unsafe { *PADDING_RSP_TABLE.get_unchecked(self.padding_rsp) }
     }
 }
 

--- a/protocol/src/msgque/mcq/text/command.rs
+++ b/protocol/src/msgque/mcq/text/command.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use sharding::hash::{Bkdr, Hash, UppercaseHashKey};
 
-use crate::{Command, OpCode, Operation};
+use crate::{OpCode, Operation};
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct CommandProperties {
@@ -34,19 +34,32 @@ impl CommandProperties {
         &self.req_type
     }
 
+    // TODO 测试完毕后清理
+    // 构建一个padding rsp，用于返回默认响应或server不可用响应
+    // 格式类似：1 VERSION 0.0.1\r\n ;
+    //          2 SERVER_ERROR mcq not available\r\n
+    // #[inline(always)]
+    // pub(super) fn build_padding_rsp(&self) -> Command {
+    //     let padding_idx = self.padding_rsp as usize;
+    //     // 注意：quit的padding rsp为0
+    //     let padding_rsp = *PADDING_RSP_TABLE
+    //         .get(padding_idx)
+    //         .expect(format!("cmd:{}/{}", self.name, padding_idx).as_str());
+    //     let mut rsp = Command::from_vec(Vec::from(padding_rsp));
+    //     rsp.set_status_ok(self.op.is_meta());
+    //     rsp
+    // }
+
     // 构建一个padding rsp，用于返回默认响应或server不可用响应
     // 格式类似：1 VERSION 0.0.1\r\n ;
     //          2 SERVER_ERROR mcq not available\r\n
     #[inline(always)]
-    pub(super) fn build_padding_rsp(&self) -> Command {
+    pub(super) fn get_padding_rsp(&self) -> &str {
         let padding_idx = self.padding_rsp as usize;
         // 注意：quit的padding rsp为0
-        let padding_rsp = *PADDING_RSP_TABLE
+        *PADDING_RSP_TABLE
             .get(padding_idx)
-            .expect(format!("cmd:{}/{}", self.name, padding_idx).as_str());
-        let mut rsp = Command::from_vec(Vec::from(padding_rsp));
-        rsp.set_status_ok(self.op.is_meta());
-        rsp
+            .expect(format!("cmd:{}/{}", self.name, padding_idx).as_str())
     }
 }
 

--- a/protocol/src/msgque/mcq/text/mod.rs
+++ b/protocol/src/msgque/mcq/text/mod.rs
@@ -66,7 +66,7 @@ impl McqText {
 
     // 协议内部的metric统计，全部放置于此
     #[inline]
-    fn metrics<M: crate::Metric<T>, T: std::ops::AddAssign<i64>>(
+    fn metrics<M: crate::Metric<T>, T: std::ops::AddAssign<i64> + std::ops::AddAssign<bool>>(
         &self,
         request: &HashedCommand,
         response: &Command,

--- a/protocol/src/msgque/mcq/text/mod.rs
+++ b/protocol/src/msgque/mcq/text/mod.rs
@@ -128,6 +128,7 @@ impl Protocol for McqText {
     >(
         &self,
         ctx: &mut C,
+        response: Option<&mut Command>,
         w: &mut W,
     ) -> Result<()> {
         let request = ctx.request();
@@ -139,7 +140,7 @@ impl Protocol for McqText {
             return Err(crate::Error::Quit);
         }
 
-        if let Some(rsp) = ctx.response() {
+        if let Some(rsp) = response {
             // 不再创建local rsp，所有server响应的rsp data长度应该大于0
             debug_assert!(rsp.len() > 0, "req:{:?}, rsp:{:?}", request, rsp);
             w.write_slice(rsp.data(), 0)?;

--- a/protocol/src/msgque/mcq/text/mod.rs
+++ b/protocol/src/msgque/mcq/text/mod.rs
@@ -139,8 +139,7 @@ impl Protocol for McqText {
             return Err(crate::Error::Quit);
         }
 
-        let response = ctx.response();
-        if let Some(rsp) = response {
+        if let Some(rsp) = ctx.response() {
             // 不再创建local rsp，所有server响应的rsp data长度应该大于0
             debug_assert!(rsp.len() > 0, "req:{:?}, rsp:{:?}", request, rsp);
             w.write_slice(rsp.data(), 0)?;
@@ -148,6 +147,7 @@ impl Protocol for McqText {
         } else {
             let padding = cfg.get_padding_rsp();
             w.write(padding.as_bytes())?;
+            // TODO 写失败尚没有统计（还没merge进来？），暂时先和dev保持一致 fishermen
         }
 
         // TODO 测试完毕后清理

--- a/protocol/src/parser.rs
+++ b/protocol/src/parser.rs
@@ -57,11 +57,13 @@ pub trait Proto: Unpin + Clone + Send + Sync + 'static {
     fn build_writeback_request<C: Commander>(&self, _ctx: &mut C, _: u32) -> Option<HashedCommand> {
         todo!("not implement");
     }
-    // 当前资源是否为cache。用来统计命中率
-    #[inline]
-    fn cache(&self) -> bool {
-        false
-    }
+
+    //TODO 移到协议层
+    // // 当前资源是否为cache。用来统计命中率
+    // #[inline]
+    // fn cache(&self) -> bool {
+    //     false
+    // }
 }
 
 pub trait RequestProcessor {
@@ -107,15 +109,6 @@ impl Command {
     pub fn new(flag: Flag, cmd: ds::MemGuard) -> Self {
         Self { flag, cmd }
     }
-
-    // TODO 测试完毕后清理
-    // 根据vec格式的data构建cmd，flag全部为默认值
-    // pub fn from_vec(data: Vec<u8>) -> Self {
-    //     Self {
-    //         flag: Flag::new(),
-    //         cmd: MemGuard::from_vec(data),
-    //     }
-    // }
 
     #[inline]
     pub fn len(&self) -> usize {
@@ -253,6 +246,7 @@ pub enum MetricName {
     Read,
     Write,
     NilConvert,
+    Cache, // cache(mc)命中率
 }
 pub trait Metric<M: std::ops::AddAssign<i64>> {
     fn get(&self, name: MetricName) -> &mut M;

--- a/protocol/src/parser.rs
+++ b/protocol/src/parser.rs
@@ -243,13 +243,16 @@ impl Debug for Command {
 pub trait Commander {
     fn request_mut(&mut self) -> &mut HashedCommand;
     fn request(&self) -> &HashedCommand;
-    fn response(&self) -> &Command;
-    fn response_mut(&mut self) -> &mut Command;
+    fn response(&self) -> Option<&Command>;
+    fn response_mut(&mut self) -> Option<&mut Command>;
+    // 请求所在的分片位置
+    fn request_shard(&self) -> usize;
 }
 
 pub enum MetricName {
     Read,
     Write,
+    NilConvert,
 }
 pub trait Metric<M: std::ops::AddAssign<i64>> {
     fn get(&self, name: MetricName) -> &mut M;

--- a/protocol/src/parser.rs
+++ b/protocol/src/parser.rs
@@ -38,10 +38,17 @@ pub trait Proto: Unpin + Clone + Send + Sync + 'static {
     fn parse_response<S: Stream>(&self, data: &mut S) -> Result<Option<Command>>;
 
     // 根据req，构建本地response响应，全部无差别构建resp，具体quit或异常，在wirte response处处理
-    fn build_local_response<F: Fn(i64) -> usize>(&self, req: &HashedCommand, dist_fn: F)
-        -> Command;
+    // fn build_local_response<F: Fn(i64) -> usize>(&self, req: &HashedCommand, dist_fn: F)
+    //     -> Command;
 
-    fn write_response<C: Commander, W: crate::Writer>(&self, ctx: &mut C, w: &mut W) -> Result<()>;
+    // fn write_response<C: Commander, W: crate::Writer>(&self, ctx: &mut C, w: &mut W) -> Result<()>;
+    fn write_response<W: crate::Writer, F: Fn(i64) -> usize>(
+        &self,
+        request: &HashedCommand,
+        response: &mut Option<Command>,
+        dist_fn: F,
+        w: &mut W,
+    ) -> Result<()>;
 
     #[inline]
     fn check(&self, _req: &HashedCommand, _resp: &Command) -> bool {
@@ -103,13 +110,16 @@ impl Command {
     pub fn new(flag: Flag, cmd: ds::MemGuard) -> Self {
         Self { flag, cmd }
     }
+
+    // TODO 测试完毕后清理
     // 根据vec格式的data构建cmd，flag全部为默认值
-    pub fn from_vec(data: Vec<u8>) -> Self {
-        Self {
-            flag: Flag::new(),
-            cmd: MemGuard::from_vec(data),
-        }
-    }
+    // pub fn from_vec(data: Vec<u8>) -> Self {
+    //     Self {
+    //         flag: Flag::new(),
+    //         cmd: MemGuard::from_vec(data),
+    //     }
+    // }
+
     #[inline]
     pub fn len(&self) -> usize {
         self.cmd.len()

--- a/protocol/src/parser.rs
+++ b/protocol/src/parser.rs
@@ -48,6 +48,7 @@ pub trait Proto: Unpin + Clone + Send + Sync + 'static {
     >(
         &self,
         ctx: &mut C,
+        response: Option<&mut Command>,
         w: &mut W,
     ) -> Result<()>;
 
@@ -58,7 +59,12 @@ pub trait Proto: Unpin + Clone + Send + Sync + 'static {
     // 构建回写请求。
     // 返回None: 说明req复用，build in place
     // 返回新的request
-    fn build_writeback_request<C: Commander>(&self, _ctx: &mut C, _: u32) -> Option<HashedCommand> {
+    fn build_writeback_request<C: Commander>(
+        &self,
+        _ctx: &mut C,
+        _response: &Command,
+        _: u32,
+    ) -> Option<HashedCommand> {
         todo!("not implement");
     }
 }
@@ -225,8 +231,9 @@ impl Debug for Command {
 pub trait Commander {
     fn request_mut(&mut self) -> &mut HashedCommand;
     fn request(&self) -> &HashedCommand;
-    fn response(&self) -> Option<&Command>;
-    fn response_mut(&mut self) -> Option<&mut Command>;
+    // response  单独拆除
+    // fn response(&self) -> Option<&Command>;
+    // fn response_mut(&mut self) -> Option<&mut Command>;
     // 请求所在的分片位置
     fn request_shard(&self) -> usize;
 }

--- a/protocol/src/phantom/command.rs
+++ b/protocol/src/phantom/command.rs
@@ -180,44 +180,6 @@ impl CommandProperties {
         HashedCommand::new(cmd, hash, flag)
     }
 
-    // TODO 上线稳定后清理，2022.12 后可清理 fishermen
-    // // 构建一个nil rsp，返回格式类似： :-10\r\n
-    // #[inline(always)]
-    // pub(super) fn build_nil_rsp(&self) -> Command {
-    //     let nil_str = self.get_nil_rsp_str();
-    //     let mut rsp = Command::from_vec(Vec::from(nil_str));
-    //     rsp.set_status_ok(false).set_nil_convert();
-    //     rsp
-    // }
-
-    // 构建一个nil rsp，返回格式类似： :-10\r\n
-    // #[inline(always)]
-    // pub(super) fn get_nil_rsp(&self) -> &str {
-    //     let nil_idx = self.nil_rsp as usize;
-    //     assert!(nil_idx > 0, "cmd:{}", self.name);
-
-    //     *PADDING_RSP_TABLE
-    //         .get(nil_idx)
-    //         .expect(format!("cmd:{}/{}", self.name, nil_idx).as_str())
-    // }
-
-    // TODO 上线稳定后清理，2022.12 后可清理 fishermen
-    // 构建一个padding rsp，用于返回默认响应或server不可用响应
-    // 格式类似：1 pong； 2 -Err redis no available
-    // #[inline(always)]
-    // pub(super) fn build_padding_rsp(&self) -> Command {
-    //     let padding_idx = self.padding_rsp as usize;
-    //     assert!(padding_idx < PADDING_RSP_TABLE.len(), "cmd:{}", self.name);
-
-    //     let padding_str = *PADDING_RSP_TABLE
-    //         .get(padding_idx)
-    //         .expect(format!("cmd:{}, padding_rsp:{}", self.name, padding_idx).as_str());
-    //     let mut rsp = Command::from_vec(Vec::from(padding_str));
-    //     // 只有meta的padding rsp才可以设status为true，其他都是异端
-    //     rsp.set_status_ok(self.op.is_meta());
-    //     rsp
-    // }
-
     // 构建一个padding rsp，用于返回默认响应或server不可用响应
     // 格式类似：1 pong； 2 -Err redis no available
     #[inline(always)]

--- a/protocol/src/phantom/command.rs
+++ b/protocol/src/phantom/command.rs
@@ -1,4 +1,4 @@
-use crate::{Command, HashedCommand, OpCode, Operation};
+use crate::{HashedCommand, OpCode, Operation};
 use ds::{MemGuard, RingSlice};
 use sharding::hash::{Crc32, Hash, UppercaseHashKey};
 
@@ -21,7 +21,9 @@ pub(crate) struct CommandProperties {
     key_step: u8,
     // 指令在不路由或者无server响应时的响应位置，
     pub(super) padding_rsp: u8,
-    pub(super) nil_rsp: u8,
+
+    // TODO 把padding、nil整合成一个，测试完毕后清理
+    // pub(super) nil_rsp: u8,
     pub(super) has_val: bool,
     pub(super) has_key: bool,
     pub(super) noforward: bool,
@@ -178,39 +180,54 @@ impl CommandProperties {
         HashedCommand::new(cmd, hash, flag)
     }
 
+    // TODO 上线稳定后清理，2022.12 后可清理 fishermen
+    // // 构建一个nil rsp，返回格式类似： :-10\r\n
+    // #[inline(always)]
+    // pub(super) fn build_nil_rsp(&self) -> Command {
+    //     let nil_str = self.get_nil_rsp_str();
+    //     let mut rsp = Command::from_vec(Vec::from(nil_str));
+    //     rsp.set_status_ok(false).set_nil_convert();
+    //     rsp
+    // }
+
     // 构建一个nil rsp，返回格式类似： :-10\r\n
-    #[inline(always)]
-    pub(super) fn build_nil_rsp(&self) -> Command {
-        let nil_str = self.get_nil_rsp_str();
-        let mut rsp = Command::from_vec(Vec::from(nil_str));
-        rsp.set_status_ok(false).set_nil_convert();
-        rsp
-    }
+    // #[inline(always)]
+    // pub(super) fn get_nil_rsp(&self) -> &str {
+    //     let nil_idx = self.nil_rsp as usize;
+    //     assert!(nil_idx > 0, "cmd:{}", self.name);
 
-    #[inline(always)]
-    pub(super) fn get_nil_rsp_str(&self) -> &str {
-        let nil_idx = self.nil_rsp as usize;
-        assert!(nil_idx > 0, "cmd:{}", self.name);
+    //     *PADDING_RSP_TABLE
+    //         .get(nil_idx)
+    //         .expect(format!("cmd:{}/{}", self.name, nil_idx).as_str())
+    // }
 
-        *PADDING_RSP_TABLE
-            .get(nil_idx)
-            .expect(format!("cmd:{}/{}", self.name, nil_idx).as_str())
-    }
+    // TODO 上线稳定后清理，2022.12 后可清理 fishermen
+    // 构建一个padding rsp，用于返回默认响应或server不可用响应
+    // 格式类似：1 pong； 2 -Err redis no available
+    // #[inline(always)]
+    // pub(super) fn build_padding_rsp(&self) -> Command {
+    //     let padding_idx = self.padding_rsp as usize;
+    //     assert!(padding_idx < PADDING_RSP_TABLE.len(), "cmd:{}", self.name);
+
+    //     let padding_str = *PADDING_RSP_TABLE
+    //         .get(padding_idx)
+    //         .expect(format!("cmd:{}, padding_rsp:{}", self.name, padding_idx).as_str());
+    //     let mut rsp = Command::from_vec(Vec::from(padding_str));
+    //     // 只有meta的padding rsp才可以设status为true，其他都是异端
+    //     rsp.set_status_ok(self.op.is_meta());
+    //     rsp
+    // }
 
     // 构建一个padding rsp，用于返回默认响应或server不可用响应
     // 格式类似：1 pong； 2 -Err redis no available
     #[inline(always)]
-    pub(super) fn build_padding_rsp(&self) -> Command {
+    pub(super) fn get_padding_rsp(&self) -> &str {
         let padding_idx = self.padding_rsp as usize;
         assert!(padding_idx < PADDING_RSP_TABLE.len(), "cmd:{}", self.name);
 
-        let padding_str = *PADDING_RSP_TABLE
+        *PADDING_RSP_TABLE
             .get(padding_idx)
-            .expect(format!("cmd:{}, padding_rsp:{}", self.name, padding_idx).as_str());
-        let mut rsp = Command::from_vec(Vec::from(padding_str));
-        // 只有meta的padding rsp才可以设status为true，其他都是异端
-        rsp.set_status_ok(self.op.is_meta());
-        rsp
+            .expect(format!("cmd:{}, padding_rsp:{}", self.name, padding_idx).as_str())
     }
 }
 
@@ -276,11 +293,12 @@ impl Commands {
         // 之前没有添加过。
         assert!(!self.supported[idx].supported);
 
+        // TODO 测试完毕后清理
         // bfmget、bfmset，在部分key 返回异常响应时，需要将异常信息转换为nil返回 fishermen
-        let mut nil_rsp = 0;
-        if uppercase.eq("BFMGET") || uppercase.eq("BFMSET") {
-            nil_rsp = 5;
-        }
+        // let mut nil_rsp = 0;
+        // if uppercase.eq("BFMGET") || uppercase.eq("BFMSET") {
+        //     nil_rsp = 5;
+        // }
 
         // 所有cmd的padding-rsp都必须是合理值，此处统一判断
         assert!(
@@ -300,7 +318,7 @@ impl Commands {
             last_key_index,
             key_step,
             padding_rsp,
-            nil_rsp,
+            // nil_rsp,
             noforward,
             supported: true,
             multi,
@@ -342,9 +360,9 @@ pub(super) mod cmd {
                 ("bfget" , "bfget",        2, Get, 1, 1, 1, 3, false, false, true, false, false),
                 ("bfset", "bfset",         2, Store, 1, 1, 1, 3, false, false, true, false, false),
 
-                // bfmget、bfmset，在部分key 返回异常响应时，需要将异常信息转换为nil返回 fishermen
-                ("bfmget", "bfget",       -2, MGet, 1, -1, 1, 3, true, false, true, false, true),
-                ("bfmset", "bfset",       -2, Store, 1, 1, 1, 3, true, false, true, false, true),
+                // bfmget、bfmset，padding改为5， fishermen
+                ("bfmget", "bfget",       -2, MGet, 1, -1, 1, 5, true, false, true, false, true),
+                ("bfmset", "bfset",       -2, Store, 1, 1, 1, 5, true, false, true, false, true),
 
 
 

--- a/protocol/src/phantom/command.rs
+++ b/protocol/src/phantom/command.rs
@@ -184,9 +184,7 @@ impl CommandProperties {
     // 格式类似：1 pong； 2 -Err redis no available
     #[inline(always)]
     pub(super) fn get_padding_rsp(&self) -> &str {
-        *PADDING_RSP_TABLE
-            .get(self.padding_rsp)
-            .expect(format!("cmd:{}, padding_rsp:{}", self.name, self.padding_rsp).as_str())
+        unsafe { *PADDING_RSP_TABLE.get_unchecked(self.padding_rsp) }
     }
 }
 

--- a/protocol/src/phantom/flag.rs
+++ b/protocol/src/phantom/flag.rs
@@ -6,23 +6,7 @@ const KEY_COUNT_BITS: u8 = 16;
 const KEY_COUNT_MASK: u64 = (1 << KEY_COUNT_BITS) - 1;
 // 32: 标识是否是第一个key
 const MKEY_FIRST_SHIFT: u8 = KEY_COUNT_SHIFT + KEY_COUNT_BITS;
-const MKEY_FIRST_BIT: u8 = 1;
-
-// TODO 去掉padding_rsp 测试完毕后清理
-// 33~35: 3bits 是 padding_rsp
-// const PADDING_RSP_SHIFT: u8 = MKEY_FIRST_SHIFT + MKEY_FIRST_BIT;
-// const PADDING_RSP_BITS: u8 = 3;
-// const PADDING_RSP_MASK: u64 = (1 << PADDING_RSP_BITS) - 1;
-
-// // 36~43 8bit
-// const META_LEN_SHIFT: u8 = PADDING_RSP_SHIFT + PADDING_RSP_BITS;
-// const META_LEN_BITS: u8 = 8;
-// const META_LEN_MASK: u64 = (1 << META_LEN_BITS) - 1;
-
-// token len 目前没有用，先注释掉 fishermen
-// const TOKEN_LEN_SHIFT: u8 = META_LEN_BITS + META_LEN_BITS;
-// const TOKEN_LEN_BITS: u8 = 8;
-// const TOKEN_LEN_MASK: u64 = (1 << TOKEN_LEN_BITS) - 1;
+const _MKEY_FIRST_BIT: u8 = 1;
 
 pub(super) trait RedisFlager {
     fn set_key_count(&mut self, cnt: u16);
@@ -31,10 +15,6 @@ pub(super) trait RedisFlager {
     fn mkey_first(&self) -> bool;
     // fn set_padding_rsp(&mut self, idx: u8);
     // fn padding_rsp(&self) -> u8;
-    // fn set_meta_len(&mut self, l: u8);
-    // fn meta_len(&self) -> u8;
-    // fn set_token_count(&mut self, c: u8);
-    // fn token_count(&self) -> u8;
 }
 
 #[inline]
@@ -76,23 +56,6 @@ impl RedisFlager for u64 {
     // fn padding_rsp(&self) -> u8 {
     //     get(self, PADDING_RSP_SHIFT, PADDING_RSP_MASK) as u8
     // }
-    // #[inline]
-    // fn set_meta_len(&mut self, l: u8) {
-    //     set(self, META_LEN_SHIFT, META_LEN_MASK, l as u64);
-    // }
-    // #[inline]
-    // fn meta_len(&self) -> u8 {
-    //     get(self, META_LEN_SHIFT, META_LEN_MASK) as u8
-    // }
-
-    // #[inline]
-    // fn set_token_count(&mut self, c: u8) {
-    //     set(self, TOKEN_LEN_SHIFT, TOKEN_LEN_MASK, c as u64);
-    // }
-    // #[inline]
-    // fn token_count(&self) -> u8 {
-    //     get(self, TOKEN_LEN_SHIFT, TOKEN_LEN_MASK) as u8
-    // }
 }
 impl RedisFlager for crate::Flag {
     #[inline]
@@ -118,22 +81,5 @@ impl RedisFlager for crate::Flag {
     // #[inline]
     // fn padding_rsp(&self) -> u8 {
     //     self.ext().padding_rsp()
-    // }
-    // #[inline]
-    // fn set_meta_len(&mut self, l: u8) {
-    //     self.ext_mut().set_meta_len(l);
-    // }
-    // #[inline]
-    // fn meta_len(&self) -> u8 {
-    //     self.ext().meta_len()
-    // }
-
-    // #[inline]
-    // fn set_token_count(&mut self, c: u8) {
-    //     self.ext_mut().set_token_count(c);
-    // }
-    // #[inline]
-    // fn token_count(&self) -> u8 {
-    //     self.ext().token_count()
     // }
 }

--- a/protocol/src/phantom/flag.rs
+++ b/protocol/src/phantom/flag.rs
@@ -7,10 +7,12 @@ const KEY_COUNT_MASK: u64 = (1 << KEY_COUNT_BITS) - 1;
 // 32: 标识是否是第一个key
 const MKEY_FIRST_SHIFT: u8 = KEY_COUNT_SHIFT + KEY_COUNT_BITS;
 const MKEY_FIRST_BIT: u8 = 1;
+
+// TODO 去掉padding_rsp 测试完毕后清理
 // 33~35: 3bits 是 padding_rsp
-const PADDING_RSP_SHIFT: u8 = MKEY_FIRST_SHIFT + MKEY_FIRST_BIT;
-const PADDING_RSP_BITS: u8 = 3;
-const PADDING_RSP_MASK: u64 = (1 << PADDING_RSP_BITS) - 1;
+// const PADDING_RSP_SHIFT: u8 = MKEY_FIRST_SHIFT + MKEY_FIRST_BIT;
+// const PADDING_RSP_BITS: u8 = 3;
+// const PADDING_RSP_MASK: u64 = (1 << PADDING_RSP_BITS) - 1;
 
 // // 36~43 8bit
 // const META_LEN_SHIFT: u8 = PADDING_RSP_SHIFT + PADDING_RSP_BITS;
@@ -27,8 +29,8 @@ pub(super) trait RedisFlager {
     fn key_count(&self) -> u16;
     fn set_mkey_first(&mut self);
     fn mkey_first(&self) -> bool;
-    fn set_padding_rsp(&mut self, idx: u8);
-    fn padding_rsp(&self) -> u8;
+    // fn set_padding_rsp(&mut self, idx: u8);
+    // fn padding_rsp(&self) -> u8;
     // fn set_meta_len(&mut self, l: u8);
     // fn meta_len(&self) -> u8;
     // fn set_token_count(&mut self, c: u8);
@@ -66,14 +68,14 @@ impl RedisFlager for u64 {
     fn mkey_first(&self) -> bool {
         *self & (1 << MKEY_FIRST_SHIFT) > 0
     }
-    #[inline]
-    fn set_padding_rsp(&mut self, padding: u8) {
-        set(self, PADDING_RSP_SHIFT, PADDING_RSP_MASK, padding as u64);
-    }
-    #[inline]
-    fn padding_rsp(&self) -> u8 {
-        get(self, PADDING_RSP_SHIFT, PADDING_RSP_MASK) as u8
-    }
+    // #[inline]
+    // fn set_padding_rsp(&mut self, padding: u8) {
+    //     set(self, PADDING_RSP_SHIFT, PADDING_RSP_MASK, padding as u64);
+    // }
+    // #[inline]
+    // fn padding_rsp(&self) -> u8 {
+    //     get(self, PADDING_RSP_SHIFT, PADDING_RSP_MASK) as u8
+    // }
     // #[inline]
     // fn set_meta_len(&mut self, l: u8) {
     //     set(self, META_LEN_SHIFT, META_LEN_MASK, l as u64);
@@ -109,14 +111,14 @@ impl RedisFlager for crate::Flag {
     fn mkey_first(&self) -> bool {
         self.ext().mkey_first()
     }
-    #[inline]
-    fn set_padding_rsp(&mut self, padding: u8) {
-        self.ext_mut().set_padding_rsp(padding);
-    }
-    #[inline]
-    fn padding_rsp(&self) -> u8 {
-        self.ext().padding_rsp()
-    }
+    // #[inline]
+    // fn set_padding_rsp(&mut self, padding: u8) {
+    //     self.ext_mut().set_padding_rsp(padding);
+    // }
+    // #[inline]
+    // fn padding_rsp(&self) -> u8 {
+    //     self.ext().padding_rsp()
+    // }
     // #[inline]
     // fn set_meta_len(&mut self, l: u8) {
     //     self.ext_mut().set_meta_len(l);

--- a/protocol/src/phantom/mod.rs
+++ b/protocol/src/phantom/mod.rs
@@ -7,9 +7,7 @@ mod flag;
 mod packet;
 //mod token;
 
-use crate::{
-    Command, Commander, Error, Flag, HashedCommand, Protocol, RequestProcessor, Result, Stream,
-};
+use crate::{Command, Error, Flag, HashedCommand, Protocol, RequestProcessor, Result, Stream};
 use ds::RingSlice;
 use flag::RedisFlager;
 use packet::Packet;
@@ -180,23 +178,24 @@ impl Protocol for Phantom {
         }
     }
 
+    //TODO 测试完毕后清理
     // 构建本地响应resp策略：
     //  1 对于multi+多bulk req，构建nil rsp；
     //  2 对其他固定响应的请求，构建padding rsp；
-    fn build_local_response<F: Fn(i64) -> usize>(
-        &self,
-        req: &HashedCommand,
-        _dist_fn: F,
-    ) -> Command {
-        let cfg = command::get_cfg(req.op_code()).expect(format!("req:{:?}", req).as_str());
+    // fn build_local_response<F: Fn(i64) -> usize>(
+    //     &self,
+    //     req: &HashedCommand,
+    //     _dist_fn: F,
+    // ) -> Command {
+    //     let cfg = command::get_cfg(req.op_code()).expect(format!("req:{:?}", req).as_str());
 
-        // 对hashkey、keyshard构建协议格式的resp，对其他请求构建nil or padding rsp
-        if cfg.multi && cfg.need_bulk_num {
-            cfg.build_nil_rsp()
-        } else {
-            cfg.build_padding_rsp()
-        }
-    }
+    //     // 对hashkey、keyshard构建协议格式的resp，对其他请求构建nil or padding rsp
+    //     if cfg.multi && cfg.need_bulk_num {
+    //         cfg.build_nil_rsp()
+    //     } else {
+    //         cfg.build_padding_rsp()
+    //     }
+    // }
 
     // 发送响应给client：
     //  1 multi + need-bulk-num，对first先发bulk num，非first正常发送；
@@ -204,19 +203,30 @@ impl Protocol for Phantom {
     //  3 quit 发送完毕后，返回Err 断开连接
     //  4 其他普通响应直接发送；
     #[inline]
-    fn write_response<C: Commander, W: crate::Writer>(&self, ctx: &mut C, w: &mut W) -> Result<()> {
-        let req = ctx.request();
-        let op_code = req.op_code();
-        let cfg = command::get_cfg(op_code)?;
-        let response = ctx.response();
+    fn write_response<W: crate::Writer, F: Fn(i64) -> usize>(
+        &self,
+        request: &HashedCommand,
+        response: &mut Option<Command>,
+        _dist_fn: F,
+        w: &mut W,
+    ) -> Result<()> {
+        // let req = ctx.request();
+        // let response = ctx.response();
+        let cfg = command::get_cfg(request.op_code())?;
         if !cfg.multi {
-            w.write_slice(response.data(), 0)?;
+            if let Some(rsp) = response {
+                w.write_slice(rsp.data(), 0)?;
+            } else {
+                let padding = cfg.get_padding_rsp();
+                w.write(padding.as_bytes())?;
+            }
+
             // quit 指令发送响应后，返回Err关闭连接
             if cfg.quit {
                 return Err(crate::Error::Quit);
             }
         } else {
-            let ext = req.ext();
+            let ext = request.ext();
             let first = ext.mkey_first();
             if first || cfg.need_bulk_num {
                 if first && cfg.need_bulk_num {
@@ -224,13 +234,24 @@ impl Protocol for Phantom {
                     w.write(ext.key_count().to_string().as_bytes())?;
                     w.write(b"\r\n")?;
                 }
-                // 对于异常响应，如果resp是多bulk的，则需要将异常响应转为nil进行响应client
-                if !response.ok() && cfg.need_bulk_num {
-                    let nil = cfg.get_nil_rsp_str();
-                    w.write(nil.as_bytes())?;
-                } else {
-                    w.write_slice(response.data(), 0)?;
+
+                // 如果rsp是ok，或者不需要bulk num，直接发送；否则构建rsp or padding rsp
+                if let Some(rsp) = response {
+                    if rsp.ok() || !cfg.need_bulk_num {
+                        w.write_slice(rsp.data(), 0)?;
+                        return Ok(());
+                    }
                 }
+                let padding = cfg.get_padding_rsp();
+                w.write(padding.as_bytes())?;
+
+                // 对于异常响应，如果resp是多bulk的，则需要将异常响应转为nil进行响应client
+                // if !response.ok() && cfg.need_bulk_num {
+                //     let nil = cfg.get_nil_rsp_str();
+                //     w.write(nil.as_bytes())?;
+                // } else {
+                //     w.write_slice(response.data(), 0)?;
+                // }
             }
             // 有些请求，如mset，不需要bulk_num,说明只需要返回一个首个key的请求即可。
             // mset always return +OK

--- a/protocol/src/phantom/mod.rs
+++ b/protocol/src/phantom/mod.rs
@@ -251,18 +251,10 @@ impl Protocol for Phantom {
                 let padding = cfg.get_padding_rsp();
                 w.write(padding.as_bytes())?;
 
-                // rsp不为ok，对need_bulk_num为false的cmd进行nil convert 统计
+                // rsp不为ok，对need_bulk_num为true的cmd进行nil convert 统计
                 if cfg.need_bulk_num {
                     *ctx.get(MetricName::NilConvert) += 1;
                 }
-
-                // 对于异常响应，如果resp是多bulk的，则需要将异常响应转为nil进行响应client
-                // if !response.ok() && cfg.need_bulk_num {
-                //     let nil = cfg.get_nil_rsp_str();
-                //     w.write(nil.as_bytes())?;
-                // } else {
-                //     w.write_slice(response.data(), 0)?;
-                // }
             }
             // 有些请求，如mset，不需要bulk_num,说明只需要返回一个首个key的请求即可。
             // mset always return +OK

--- a/protocol/src/phantom/mod.rs
+++ b/protocol/src/phantom/mod.rs
@@ -212,11 +212,11 @@ impl Protocol for Phantom {
     >(
         &self,
         ctx: &mut C,
+        response: Option<&mut Command>,
         w: &mut W,
     ) -> Result<()> {
         let request = ctx.request();
         let cfg = command::get_cfg(request.op_code())?;
-        let response = ctx.response();
 
         if !cfg.multi {
             if let Some(rsp) = response {

--- a/protocol/src/redis/command.rs
+++ b/protocol/src/redis/command.rs
@@ -70,9 +70,7 @@ impl CommandProperties {
     // 响应格式类似：1 pong； 2 -Err redis no available; 3 $-1\r\n
     #[inline(always)]
     pub(super) fn get_padding_rsp(&self) -> &str {
-        *PADDING_RSP_TABLE
-            .get(self.padding_rsp)
-            .expect(format!("cmd:{}, padding_rsp:{}", self.name, self.padding_rsp).as_str())
+        unsafe { *PADDING_RSP_TABLE.get_unchecked(self.padding_rsp) }
     }
 
     // 构建hashkey的resp,格式:1\r\n

--- a/protocol/src/redis/flag.rs
+++ b/protocol/src/redis/flag.rs
@@ -6,11 +6,13 @@ const KEY_COUNT_BITS: u8 = 16;
 const KEY_COUNT_MASK: u64 = (1 << KEY_COUNT_BITS) - 1;
 // 32: 标识是否是第一个key
 const MKEY_FIRST_SHIFT: u8 = KEY_COUNT_SHIFT + KEY_COUNT_BITS;
-const MKEY_FIRST_BIT: u8 = 1;
+// const MKEY_FIRST_BIT: u8 = 1;  // 这个先保留，后续增加字段时需要
+
+// TODO 测试完毕后清理 deadcode
 // 33~35: 3bits 是 padding_rsp
-const PADDING_RSP_SHIFT: u8 = MKEY_FIRST_SHIFT + MKEY_FIRST_BIT;
-const PADDING_RSP_BITS: u8 = 3;
-const PADDING_RSP_MASK: u64 = (1 << PADDING_RSP_BITS) - 1;
+// const PADDING_RSP_SHIFT: u8 = MKEY_FIRST_SHIFT + MKEY_FIRST_BIT;
+// const PADDING_RSP_BITS: u8 = 3;
+// const PADDING_RSP_MASK: u64 = (1 << PADDING_RSP_BITS) - 1;
 
 // 这些目前不再使用，暂时保留到2022.12 之后清理
 // // 36~43 8bit
@@ -28,8 +30,9 @@ pub(super) trait RedisFlager {
     fn key_count(&self) -> u16;
     fn set_mkey_first(&mut self);
     fn mkey_first(&self) -> bool;
-    fn set_padding_rsp(&mut self, idx: u8);
-    fn padding_rsp(&self) -> u8;
+
+    // fn set_padding_rsp(&mut self, idx: u8);
+    // fn padding_rsp(&self) -> u8;
     // fn set_ignore_rsp(&mut self, ignore_rsp: bool);
     // fn ignore_rs(&self) -> bool;
 
@@ -70,14 +73,14 @@ impl RedisFlager for u64 {
     fn mkey_first(&self) -> bool {
         *self & (1 << MKEY_FIRST_SHIFT) > 0
     }
-    #[inline]
-    fn set_padding_rsp(&mut self, padding: u8) {
-        set(self, PADDING_RSP_SHIFT, PADDING_RSP_MASK, padding as u64);
-    }
-    #[inline]
-    fn padding_rsp(&self) -> u8 {
-        get(self, PADDING_RSP_SHIFT, PADDING_RSP_MASK) as u8
-    }
+    // #[inline]
+    // fn set_padding_rsp(&mut self, padding: u8) {
+    //     set(self, PADDING_RSP_SHIFT, PADDING_RSP_MASK, padding as u64);
+    // }
+    // #[inline]
+    // fn padding_rsp(&self) -> u8 {
+    //     get(self, PADDING_RSP_SHIFT, PADDING_RSP_MASK) as u8
+    // }
     // #[inline]
     // fn set_meta_len(&mut self, l: u8) {
     //     set(self, META_LEN_SHIFT, META_LEN_MASK, l as u64);
@@ -112,14 +115,16 @@ impl RedisFlager for crate::Flag {
     fn mkey_first(&self) -> bool {
         self.ext().mkey_first()
     }
-    #[inline]
-    fn set_padding_rsp(&mut self, padding: u8) {
-        self.ext_mut().set_padding_rsp(padding);
-    }
-    #[inline]
-    fn padding_rsp(&self) -> u8 {
-        self.ext().padding_rsp()
-    }
+
+    // TODO deadcode 测试完毕后清理
+    // #[inline]
+    // fn set_padding_rsp(&mut self, padding: u8) {
+    //     self.ext_mut().set_padding_rsp(padding);
+    // }
+    // #[inline]
+    // fn padding_rsp(&self) -> u8 {
+    //     self.ext().padding_rsp()
+    // }
     // #[inline]
     // fn set_meta_len(&mut self, l: u8) {
     //     self.ext_mut().set_meta_len(l);

--- a/protocol/src/redis/flag.rs
+++ b/protocol/src/redis/flag.rs
@@ -6,37 +6,20 @@ const KEY_COUNT_BITS: u8 = 16;
 const KEY_COUNT_MASK: u64 = (1 << KEY_COUNT_BITS) - 1;
 // 32: 标识是否是第一个key
 const MKEY_FIRST_SHIFT: u8 = KEY_COUNT_SHIFT + KEY_COUNT_BITS;
-const MKEY_FIRST_BIT: u8 = 1;  // 这个先保留，后续增加字段时需要
-// 33: master_only
+const MKEY_FIRST_BIT: u8 = 1; // 这个先保留，后续增加字段时需要
+                              // 33: master_only
 const MASTER_ONLY_SHIFT: u8 = MKEY_FIRST_SHIFT + MKEY_FIRST_BIT;
 const MASTER_ONLY_BIT: u8 = 1;
 // 34: direct_hash
 const DIRECT_HASH_SHIFT: u8 = MASTER_ONLY_SHIFT + MASTER_ONLY_BIT;
 const _DIRECT_HASH_BIT: u8 = 1;
 
-// 这些目前不再使用，暂时保留到2022.12 之后清理
-// TODO 测试完毕后清理 deadcode
-// 33~35: 3bits 是 padding_rsp
-// const PADDING_RSP_SHIFT: u8 = MKEY_FIRST_SHIFT + MKEY_FIRST_BIT;
-// const PADDING_RSP_BITS: u8 = 3;
-// const PADDING_RSP_MASK: u64 = (1 << PADDING_RSP_BITS) - 1;
-
-// // 36~43 8bit
-// const META_LEN_SHIFT: u8 = PADDING_RSP_SHIFT + PADDING_RSP_BITS;
-// const META_LEN_BITS: u8 = 8;
-// const META_LEN_MASK: u64 = (1 << META_LEN_BITS) - 1;
-
-// token len 目前没有用，先注释掉 fishermen
-// const TOKEN_LEN_SHIFT: u8 = META_LEN_BITS + META_LEN_BITS;
-// const TOKEN_LEN_BITS: u8 = 8;
-// const TOKEN_LEN_MASK: u64 = (1 << TOKEN_LEN_BITS) - 1;
-
 pub trait RedisFlager {
     fn set_key_count(&mut self, cnt: u16);
     fn key_count(&self) -> u16;
     fn set_mkey_first(&mut self);
     fn mkey_first(&self) -> bool;
-    
+
     // fn set_padding_rsp(&mut self, idx: u8);
     // fn padding_rsp(&self) -> u8;
 
@@ -44,7 +27,7 @@ pub trait RedisFlager {
     fn master_only(&self) -> bool;
     fn set_direct_hash(&mut self);
     fn direct_hash(&self) -> bool;
-    
+
     // fn set_ignore_rsp(&mut self, ignore_rsp: bool);
     // fn ignore_rs(&self) -> bool;
 
@@ -75,16 +58,16 @@ impl RedisFlager for u64 {
         self.get(MKEY_FIRST_SHIFT)
     }
 
-？拉到本地fix
-    #[inline]
-    fn set_padding_rsp(&mut self, padding: u8) {
-        self.mask_set(PADDING_RSP_SHIFT, PADDING_RSP_MASK, padding as u64);
-    }
-    #[inline]
-    fn padding_rsp(&self) -> u8 {
-        self.mask_get(PADDING_RSP_SHIFT, PADDING_RSP_MASK) as u8
-    }
-    
+    // TODO 暂时保留，备查及比对，待上线稳定一段时间后再删除，2022.12可删
+    // #[inline]
+    // fn set_padding_rsp(&mut self, padding: u8) {
+    //     self.mask_set(PADDING_RSP_SHIFT, PADDING_RSP_MASK, padding as u64);
+    // }
+    // #[inline]
+    // fn padding_rsp(&self) -> u8 {
+    //     self.mask_get(PADDING_RSP_SHIFT, PADDING_RSP_MASK) as u8
+    // }
+
     #[inline]
     fn set_master_only(&mut self) {
         self.set(MASTER_ONLY_SHIFT)
@@ -101,21 +84,4 @@ impl RedisFlager for u64 {
     fn direct_hash(&self) -> bool {
         self.get(DIRECT_HASH_SHIFT)
     }
-    
-    // #[inline]
-    // fn set_meta_len(&mut self, l: u8) {
-    //     set(self, META_LEN_SHIFT, META_LEN_MASK, l as u64);
-    // }
-    // #[inline]
-    // fn meta_len(&self) -> u8 {
-    //     get(self, META_LEN_SHIFT, META_LEN_MASK) as u8
-    // }
-    // #[inline]
-    // fn set_token_count(&mut self, c: u8) {
-    //     set(self, TOKEN_LEN_SHIFT, TOKEN_LEN_MASK, c as u64);
-    // }
-    // #[inline]
-    // fn token_count(&self) -> u8 {
-    //     get(self, TOKEN_LEN_SHIFT, TOKEN_LEN_MASK) as u8
-    // }
 }

--- a/protocol/src/redis/mod.rs
+++ b/protocol/src/redis/mod.rs
@@ -317,11 +317,11 @@ impl Protocol for Redis {
     >(
         &self,
         ctx: &mut C,
+        response: Option<&mut Command>,
         w: &mut W,
     ) -> Result<()> {
         let request = ctx.request();
         let cfg = command::get_cfg(request.op_code())?;
-        let response = ctx.response();
 
         if !cfg.multi {
             // 非multi请求,有响应直接返回client，否则构建
@@ -470,7 +470,12 @@ impl Protocol for Redis {
 
     // redis writeback场景：hashkey -1 时，需要对所有节点进行数据（一般为script）分发
     #[inline]
-    fn build_writeback_request<C: Commander>(&self, ctx: &mut C, _: u32) -> Option<HashedCommand> {
+    fn build_writeback_request<C: Commander>(
+        &self,
+        ctx: &mut C,
+        _response: &Command,
+        _: u32,
+    ) -> Option<HashedCommand> {
         let hash_cmd = ctx.request_mut();
         debug_assert!(hash_cmd.direct_hash(), "data: {:?}", hash_cmd.data());
 

--- a/protocol/src/redis/mod.rs
+++ b/protocol/src/redis/mod.rs
@@ -303,7 +303,7 @@ impl Protocol for Redis {
     //     rsp
     // }
 
-    // TODO：当前把padding、nil整合成一个，接下来把spec-rsp也整合进来
+    // TODO：当前把padding、nil整合成一个，后续考虑如何把spec-rsp也整合进来
     // 发送响应给client：
     //  1 非multi，有rsponse直接发送，否则构建padding or spec-rsp后发送；
     //  2 multi，need-bulk-num为true，有response+ok直接发送，否则构建padding or spec-rsp后发送；
@@ -380,18 +380,10 @@ impl Protocol for Redis {
                     }
                 };
 
-                // rsp不为ok，对need_bulk_num为false的cmd进行nil convert 统计
+                // rsp不为ok，对need_bulk_num为true的cmd进行nil convert 统计
                 if cfg.need_bulk_num {
                     *ctx.get(MetricName::NilConvert) += 1;
                 }
-
-                // if !rsp_ok && cfg.need_bulk_num {
-                //     // let nil = cfg.get_nil_rsp_str();
-                //     // w.write(nil.as_bytes())?;
-                //     w.write(self.build_local_response(request, dist_fn).as_bytes())?;
-                // } else {
-                //     w.write_slice(response.data(), 0)?;
-                // }
             }
             // 有些请求，如mset，不需要bulk_num,说明只需要返回一个首个key的请求即可；这些响应直接吞噬。
             // mset always return +OK

--- a/stream/src/context.rs
+++ b/stream/src/context.rs
@@ -30,7 +30,10 @@ impl CallbackContextPtr {
         assert!(!self.inited() && self.complete(), "cbptr:{:?}", &**self);
         self.async_mode();
         if let Some(new) = parser.build_writeback_request(
-            &mut ResponseContext::new(self, Some(&mut res), metric, |_h| 0),
+            &mut ResponseContext::new(self, Some(&mut res), metric, |_h| {
+                assert!(false, "write back"); // 此处的dist_fn逻辑上暂时不用
+                0
+            }),
             exp,
         ) {
             self.with_request(new);

--- a/stream/src/metric.rs
+++ b/stream/src/metric.rs
@@ -61,6 +61,7 @@ impl ProtoMetric<Metric> for CbMetrics {
             MetricName::Read => self.read(),
             MetricName::Write => self.write(),
             MetricName::NilConvert => self.nilconvert(),
+            MetricName::Cache => self.cache(),
         }
     }
 }

--- a/stream/src/metric.rs
+++ b/stream/src/metric.rs
@@ -60,6 +60,7 @@ impl ProtoMetric<Metric> for CbMetrics {
         match name {
             MetricName::Read => self.read(),
             MetricName::Write => self.write(),
+            MetricName::NilConvert => self.nilconvert(),
         }
     }
 }

--- a/stream/src/pipeline.rs
+++ b/stream/src/pipeline.rs
@@ -197,9 +197,8 @@ where
 
             assert!(!ctx.inited(), "ctx req:[{:?}]", ctx.request(),);
             parser.write_response(
-                &mut ResponseContext::new(&mut ctx, response.as_mut(), metrics, |hash| {
-                    self.top.shard_idx(hash)
-                }),
+                &mut ResponseContext::new(&mut ctx, metrics, |hash| self.top.shard_idx(hash)),
+                response.as_mut(),
                 client,
             )?;
 

--- a/tests/src/redis.rs
+++ b/tests/src/redis.rs
@@ -52,7 +52,7 @@ mod redis_test {
         cmd.set_direct_hash();
         assert!(cmd.direct_hash());
         //direct_hash所在位
-        cmd.ext_mut().clear(37);
+        cmd.ext_mut().clear(34);
         assert!(!cmd.direct_hash());
         //对前面设置的flag没有影响
         assert!(cmd.master_only());


### PR DESCRIPTION
1 将response的构建统一放在write_rsp的时候（整合write_noforward、build_local 到 write_rsp）；   
2 整合padding和nil rsp;   
3 req、resp、dist_fn整合到respContext中；  
4 flag去掉padding_rsp;  
5 pipeline中的协议相关metrics调整到protocol；