### PR TITLE
避免topo更新失败后丢失本次待变更通知

### DIFF
--- a/endpoint/src/phantomservice/topo.rs
+++ b/endpoint/src/phantomservice/topo.rs
@@ -184,7 +184,7 @@ where
     }
     #[inline]
     fn load(&mut self) {
-        // 先改状态，再load，如果失败再改一个状态，确保下次重试，同时避免变更过程中新的并发变更，待讨论 fishermen
+        // 先改通知状态，再load，如果失败改一个通用状态，确保下次重试，同时避免变更过程中新的并发变更，待讨论 fishermen
         for (_, updated) in self.updated.iter() {
             updated.store(false, Ordering::Release);
         }
@@ -194,9 +194,9 @@ where
         if !succeed {
             self.updated
                 .get_mut(CONFIG_UPDATED_KEY)
-                .expect("redis config state missed")
+                .expect("phantom config state missed")
                 .store(true, Ordering::Release);
-            log::error!("redis will reload topo later...");
+            log::warn!("phantom will reload topo later...");
         }
     }
 }

--- a/endpoint/src/phantomservice/topo.rs
+++ b/endpoint/src/phantomservice/topo.rs
@@ -184,11 +184,45 @@ where
     }
     #[inline]
     fn load(&mut self) {
-        // 把通知放在最前面，避免丢失通知
+        // 先改状态，再load，如果失败再改一个状态，确保下次重试，同时避免变更过程中新的并发变更，待讨论 fishermen
         for (_, updated) in self.updated.iter() {
             updated.store(false, Ordering::Release);
         }
 
+        // 根据最新配置更新topo，如果更新失败，将CONFIG_UPDATED_KEY设为true，强制下次重新加载
+        let succeed = self.load_inner();
+        if !succeed {
+            self.updated
+                .get_mut(CONFIG_UPDATED_KEY)
+                .expect("redis config state missed")
+                .store(true, Ordering::Release);
+            log::error!("redis will reload topo later...");
+        }
+    }
+}
+
+impl<B, E, Req, P> PhantomService<B, E, Req, P>
+where
+    B: Builder<P, Req, E>,
+    P: Protocol,
+    E: Endpoint<Item = Req>,
+{
+    fn build(
+        &self,
+        old: &mut HashMap<String, E>,
+        backend: Backend,
+        name: &str,
+        timeout: Duration,
+    ) -> Shards<E, Req> {
+        Shards::from(backend.distribution.as_str(), backend.servers, |addr| {
+            old.remove(addr).map(|e| e).unwrap_or_else(|| {
+                B::build(addr, self.parser.clone(), Resource::Phantom, name, timeout)
+            })
+        })
+    }
+
+    #[inline]
+    fn load_inner(&mut self) -> bool {
         let mut addrs = Vec::with_capacity(self.streams_backend.len());
         for b in self.streams_backend.iter() {
             let mut stream = Vec::with_capacity(b.servers.len());
@@ -197,7 +231,7 @@ where
                 let ips = dns::lookup_ips(host_url);
                 if ips.len() == 0 {
                     log::warn!("phantom dns looked up failed for {}", hp);
-                    return;
+                    return false;
                 }
                 if ips.len() > 1 {
                     log::warn!(
@@ -230,27 +264,8 @@ where
             let shard = self.build(&mut old, b, self.service.as_str(), self.timeout);
             self.streams.push((shard, access_mod));
         }
-    }
-}
 
-impl<B, E, Req, P> PhantomService<B, E, Req, P>
-where
-    B: Builder<P, Req, E>,
-    P: Protocol,
-    E: Endpoint<Item = Req>,
-{
-    fn build(
-        &self,
-        old: &mut HashMap<String, E>,
-        backend: Backend,
-        name: &str,
-        timeout: Duration,
-    ) -> Shards<E, Req> {
-        Shards::from(backend.distribution.as_str(), backend.servers, |addr| {
-            old.remove(addr).map(|e| e).unwrap_or_else(|| {
-                B::build(addr, self.parser.clone(), Resource::Phantom, name, timeout)
-            })
-        })
+        true
     }
 }
 

--- a/endpoint/src/redisservice/topo.rs
+++ b/endpoint/src/redisservice/topo.rs
@@ -213,7 +213,7 @@ where
 
     #[inline]
     fn load(&mut self) {
-        // TODO: 先改状态，再load，如果失败，再改一个状态，确保下次重试，同时避免变更过程中新的并发变更，待讨论 fishermen
+        // TODO: 先改通知状态，再load，如果失败，改一个通用状态，确保下次重试，同时避免变更过程中新的并发变更，待讨论 fishermen
         for (_, updated) in self.updated.iter() {
             updated.store(false, Ordering::Release);
         }
@@ -225,7 +225,7 @@ where
                 .get_mut(CONFIG_UPDATED_KEY)
                 .expect("redis config state missed")
                 .store(true, Ordering::Release);
-            log::error!("redis will reload topo later...");
+            log::warn!("redis will reload topo later...");
         }
     }
 }


### PR DESCRIPTION
修改应对两种可能的变更状态丢失：  
1. 本次更新失败后，不能丢失本次的变更通知，需要下次重试；  
2. 本次更新过程中，如果正好有状态更新通知，不能丢失新的更新通知；