### PR TITLE
后端资源异常时，对gets需要返回空响应，避免异常断连

### DIFF
--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -127,7 +127,6 @@ impl Protocol for MemcacheBinary {
         // 先进行metrics统计
         self.metrics(ctx.request(), None, ctx);
 
-        log::debug!("+++ proc no resp for req: {}/{:?}",  old_op_code, ctx.request());
         match old_op_code as u8 {
             // noop: 第一个字节变更为Response，其他的与Request保持一致
             OP_CODE_NOOP => {

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -153,7 +153,7 @@ impl Protocol for MemcacheBinary {
             }
             // self.build_empty_response(RespStatus::NotStored, req)
 
-            // get，返回key not found 对应的0x1
+            // get/gets，返回key not found 对应的0x1
             OP_CODE_GET | OP_CODE_GETS => {
                 w.write(&self.build_empty_response(RespStatus::NotFound, ctx.request()))?
             }

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -162,7 +162,7 @@ impl Protocol for MemcacheBinary {
 
             // TODO：之前是直接mesh断连接，现在返回异常rsp，由client决定应对，观察副作用 fishermen
             _ => {
-                log::error!("+++ NoResponseFound req: {:?}",  ctx.request());
+                log::error!("+++ NoResponseFound req: {}/{:?}",  old_op_code, ctx.request());
                 return Err(Error::NoResponseFound);
             },
         }

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -154,9 +154,10 @@ impl Protocol for MemcacheBinary {
             // self.build_empty_response(RespStatus::NotStored, req)
 
             // get，返回key not found 对应的0x1
-            OP_CODE_GET => {
+            OP_CODE_GET | OP_CODE_GETS => {
                 w.write(&self.build_empty_response(RespStatus::NotFound, ctx.request()))?
             }
+
             // self.build_empty_response(RespStatus::NotFound, req)
 
             // TODO：之前是直接mesh断连接，现在返回异常rsp，由client决定应对，观察副作用 fishermen

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -162,7 +162,7 @@ impl Protocol for MemcacheBinary {
 
             // TODO：之前是直接mesh断连接，现在返回异常rsp，由client决定应对，观察副作用 fishermen
             _ => {
-                log::debug!("+++ NoResponseFound req: {:?}",  ctx.request());
+                log::error!("+++ NoResponseFound req: {:?}",  ctx.request());
                 return Err(Error::NoResponseFound);
             },
         }

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -127,6 +127,7 @@ impl Protocol for MemcacheBinary {
         // 先进行metrics统计
         self.metrics(ctx.request(), None, ctx);
 
+        log::debug!("+++ proc no resp for req: {}/{:?}",  old_op_code, ctx.request());
         match old_op_code as u8 {
             // noop: 第一个字节变更为Response，其他的与Request保持一致
             OP_CODE_NOOP => {
@@ -162,7 +163,7 @@ impl Protocol for MemcacheBinary {
 
             // TODO：之前是直接mesh断连接，现在返回异常rsp，由client决定应对，观察副作用 fishermen
             _ => {
-                log::error!("+++ NoResponseFound req: {}/{:?}",  old_op_code, ctx.request());
+                log::warn!("+++ mc NoResponseFound req: {}/{:?}",  old_op_code, ctx.request());
                 return Err(Error::NoResponseFound);
             },
         }

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -161,7 +161,10 @@ impl Protocol for MemcacheBinary {
             // self.build_empty_response(RespStatus::NotFound, req)
 
             // TODO：之前是直接mesh断连接，现在返回异常rsp，由client决定应对，观察副作用 fishermen
-            _ => return Err(Error::NoResponseFound),
+            _ => {
+                log::debug!("+++ NoResponseFound req: {:?}",  ctx.request());
+                return Err(Error::NoResponseFound);
+            },
         }
         Ok(())
     }

--- a/protocol/src/memcache/binary/packet.rs
+++ b/protocol/src/memcache/binary/packet.rs
@@ -124,8 +124,9 @@ pub(super) const OP_CODE_SET: u8 = 0x01;
 //pub(super) const OP_CODE_GETK: u8 = 0x0c;
 
 // 这个专门为gets扩展
-//pub(super) const OP_CODE_GETS: u8 = 0x48;
-//pub(super) const OP_CODE_GETSQ: u8 = 0x49;
+pub(super) const OP_CODE_GETS: u8 = 0x48;
+// 这个没有业务使用，先注销掉
+// pub(super) const OP_CODE_GETSQ: u8 = 0x49;
 
 //pub(super) const OP_CODE_ADD: u8 = 0x02;
 //pub(super) const OP_CODE_DEL: u8 = 0x04;

--- a/protocol/src/msgque/mcq/binary/mod.rs
+++ b/protocol/src/msgque/mcq/binary/mod.rs
@@ -122,7 +122,9 @@ impl Protocol for McqBinary {
                 w.write(&self.build_empty_response(0x1, req.data()))?;
                 Ok(0)
             } // get: 0x01 NotFound
-            _ => Err(Error::NoResponseFound),
+            _ => {
+                log::warn!("+++ mcq NoResponseFound req: {}/{:?}",  old_op_code, ctx.request());
+                return Err(Error::NoResponseFound); },
         }
     }
     #[inline]


### PR DESCRIPTION
gets 在资源异常时，没有处理，从而默认返回Err，导致mesh和sdk之间的连接断开；   
修改为：返回empty response。