### PR TITLE
优先从环境变量获取资源访问local策略

### DIFF
--- a/endpoint/src/cacheservice/config.rs
+++ b/endpoint/src/cacheservice/config.rs
@@ -38,6 +38,15 @@ pub struct Namespace {
 }
 
 impl Namespace {
+    pub(crate) fn is_local(&self) -> bool {
+        self.local_affinity || match std::env::var("BREEZE_LOCAL")
+                .unwrap_or("".to_string())
+                .as_str()
+            {
+                "distance" => true,
+                _ => false,
+            }
+    }
     //pub(crate) fn local_len(&self) -> usize {
     //    1 + self.master_l1.len()
     //}

--- a/endpoint/src/cacheservice/topo.rs
+++ b/endpoint/src/cacheservice/topo.rs
@@ -197,7 +197,7 @@ where
 
             use discovery::distance::{Balance, ByDistance};
             let master = ns.master.clone();
-            let local = ns.local_affinity;
+            let local = ns.is_local();
             let (mut local_len, mut backends) = ns.take_backends();
             //let local = true;
             if local && local_len > 1 {

--- a/endpoint/src/redisservice/config.rs
+++ b/endpoint/src/redisservice/config.rs
@@ -40,6 +40,17 @@ pub struct Basic {
 }
 
 impl RedisNamespace {
+    pub(super) fn local(&self) -> String {
+        match std::env::var("BREEZE_LOCAL")
+            .unwrap_or("".to_string())
+            .as_str()
+        {
+            "distance" => "distance",
+            _ => self.basic.selector.as_str(),
+        }
+        .to_string()
+    }
+
     pub(super) fn try_from(cfg: &str) -> Option<Self> {
         let nso = serde_yaml::from_str::<RedisNamespace>(cfg)
             .map_err(|e| {

--- a/endpoint/src/redisservice/topo.rs
+++ b/endpoint/src/redisservice/topo.rs
@@ -151,7 +151,7 @@ where
             self.timeout_slave.adjust(ns.basic.timeout_ms_slave);
             self.hasher = Hasher::from(&ns.basic.hash);
             self.distribute = Distribute::from(ns.basic.distribution.as_str(), &ns.backends);
-            self.selector = ns.basic.selector.as_str().into();
+            self.selector = ns.local().as_str().into();
 
             // TODO 直接设置selector属性，在更新最后，设置全局更新标志，deadcode暂时保留，观察副作用 2022.12后可以删除
             // selector属性更新与域名实例更新保持一致


### PR DESCRIPTION
若环境变量 BREEZE_LOCAL 的取值为允许local，则访问资源时按local的策略访问资源；否则按照资源元数据配置决定是否按local的策略访问该资源