### PR TITLE
Support hash mixnum

### DIFF
--- a/sharding/src/hash/crc32.rs
+++ b/sharding/src/hash/crc32.rs
@@ -63,7 +63,7 @@ pub struct Crc32Delimiter {
 #[derive(Default, Clone, Debug)]
 pub struct Crc32SmartNum {}
 
-// mixnum: 两串num拼接成一个字串num做hashkey
+// mixnum: key中两串num拼接成一个字串num做hashkey，like a_123_456_bc的hashkey是123456
 #[derive(Default, Clone, Debug)]
 pub struct Crc32MixNum {}
 
@@ -291,15 +291,15 @@ pub(crate) fn parse_smartnum_hashkey<S: super::HashKey>(key: &S) -> (usize, usiz
     (start, end)
 }
 
-// 将分隔符分开的两个字符串num合并到一起来计算hash，如abc_123_456_cde、123_456_xx的hashkey都是: 123456
+// 将key中分隔符分开的两个num合并到一起来计算hash，如abc_123_456_cde、123_456_xx的hashkey都是: 123456
 impl super::Hash for Crc32MixNum {
     fn hash<S: super::HashKey>(&self, key: &S) -> i64 {
-        // 将分隔符分开的两个字符串num合并到一起来计算hash
-
         const MAX_NUM_COUNT: u32 = 2;
         let mut num_count = 0;
         let mut num_started = false;
         let mut crc: i64 = CRC_SEED;
+
+        // 找出最多两个num来作为hashkey
         for i in 0..key.len() {
             let c = key.at(i);
             if c.is_ascii_digit() {

--- a/sharding/src/hash/crc32.rs
+++ b/sharding/src/hash/crc32.rs
@@ -63,7 +63,7 @@ pub struct Crc32Delimiter {
 #[derive(Default, Clone, Debug)]
 pub struct Crc32SmartNum {}
 
-// mixnum: key中两串num拼接成一个字串num做hashkey，like a_123_456_bc的hashkey是123456
+// mixnum: key中所有num拼接成一个字串num做hashkey，like a_123_456_bc的hashkey是123456
 #[derive(Default, Clone, Debug)]
 pub struct Crc32MixNum {}
 

--- a/sharding/src/hash/mod.rs
+++ b/sharding/src/hash/mod.rs
@@ -32,7 +32,7 @@ const CRC32_EXT_NUM: &str = "num";
 const CRC32_EXT_SMARTNUM: &str = "smartnum";
 // smart num的hashkey最小长度为5
 const SMARTNUM_MIN_LEN: usize = 5;
-// mixnum 的 hashkey 是最前面2串num的混合
+// mixnum 的 hashkey 是所有key中num的混合
 const CRC32_EXT_MIXNUM: &str = "mixnum";
 
 // hash key是点号"."分割的之前/后的部分
@@ -63,7 +63,7 @@ pub enum Hasher {
     Crc32Short(Crc32Short),         // mc short crc32
     Crc32Num(Crc32Num),             // crc32 for a hash key whick is a num,
     Crc32SmartNum(Crc32SmartNum),   // crc32 for key like： xxx + id + xxx，id的长度需要大于等于5
-    Crc32MixNum(Crc32MixNum), // crc32 for key: xx_num1_num2_xx，最初两个num即hashkey(num1num2)
+    Crc32MixNum(Crc32MixNum),       // crc32 for key: xx_num1_num2_xx，所有num即hashkey(num1num2)
     Crc32Delimiter(Crc32Delimiter), // crc32 for a hash key which has a delimiter of "." or "_" or "#" etc.
     Crc32local(Crc32local),         // crc32local for a hash key like: xx.x, xx_x, xx#x etc.
     Crc32localDelimiter(Crc32localDelimiter),


### PR DESCRIPTION
支持crc32-mixnum： key中前两个字串id拼接为一个id，作为hashkey。    
eg： 123_456_w、abc_123_456_def、123#456.def 的hashkey都是：123456