### PR TITLE
Dev

### DIFF
--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -19,6 +19,7 @@ stream = { path = "../stream" }
 metrics = { path = "../metrics" }
 rt = { path = "../rt" }
 ds = { path = "../ds" }
+#[cfg(feature = "console-api")]
 api = { path = "../api" }
 
 backtrace = "0.3.63"
@@ -30,14 +31,10 @@ once_cell = "*"
 rlimit = "0.8.3"
 
 # rocket for restful api
-rocket = { version = "0.5.0-rc.2", features = ["json"], default-features = false }
+rocket = { version = "0.5.0-rc.3", features = [], default-features = false }
 #rocket_async_compression = "0.1.2"
 reqwest = { version = "0.11.4", default-features = false }
 
 
 [features]
-default = ["prometheus"]
-http = []
-console-api = ["http"]
-graphite = []
-prometheus = ["http"]
+console-api = []

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -37,4 +37,6 @@ reqwest = { version = "0.11.4", default-features = false }
 
 
 [features]
-console-api = []
+default = ["http"]
+http = []
+console-api = ["http"]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -15,7 +15,7 @@ tokio.workspace = true
 trust-dns-resolver = "0.22.0"
 
 # rocket for restful api
-rocket = { version = "0.5.0-rc.2", features = ["json"], default-features = false }
+rocket = { version = "0.5.0-rc.3", features = ["json"], default-features = false }
 lazy_static = "1.4.0"
 
 # for serde json

--- a/context/src/lib.rs
+++ b/context/src/lib.rs
@@ -330,6 +330,9 @@ impl From<ContextOption> for Context {
         if option.cpu == "v3" {
             version.push('3');
         }
+        if std::env::var("BREEZE_LOCAL") == Ok("distance".to_string()) {
+            version.push('t');
+        }
         let host_v3 = option.cpu == "v3";
         // 1. 如果宿主机的支持模式与编译器的编译方式不一致。
         if cfg!(target_feature = "avx") != host_v3 {

--- a/ds/src/mem/guarded.rs
+++ b/ds/src/mem/guarded.rs
@@ -82,6 +82,20 @@ pub struct MemGuard {
     guard: Option<Guard>, //  当前guard是否拥有mem。如果拥有，则在drop时需要手工销毁内存
 }
 
+impl Deref for MemGuard {
+    type Target = RingSlice;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.mem
+    }
+}
+impl DerefMut for MemGuard {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.mem
+    }
+}
+
 impl MemGuard {
     #[inline]
     fn new(data: RingSlice, guard: Guard) -> Self {
@@ -99,18 +113,18 @@ impl MemGuard {
         Self { mem, guard: None }
     }
 
-    #[inline]
-    pub fn data(&self) -> &RingSlice {
-        &self.mem
-    }
-    #[inline]
-    pub fn data_mut(&mut self) -> &mut RingSlice {
-        &mut self.mem
-    }
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.mem.len()
-    }
+    //#[inline]
+    //pub fn data(&self) -> &RingSlice {
+    //    &self.mem
+    //}
+    //#[inline]
+    //pub fn data_mut(&mut self) -> &mut RingSlice {
+    //    &mut self.mem
+    //}
+    //#[inline]
+    //pub fn len(&self) -> usize {
+    //    self.mem.len()
+    //}
 }
 impl Drop for MemGuard {
     #[inline]

--- a/ds/src/mem/ring_slice.rs
+++ b/ds/src/mem/ring_slice.rs
@@ -266,10 +266,16 @@ impl RingSlice {
             }
         )
     }
+    // 读取一个u16的数字，大端
+    #[inline(always)]
+    pub fn read_u16(&self, oft: usize) -> u16 {
+        debug_assert!(self.len() >= oft + 2);
+        (self[oft] as u16) << 8 | self[oft + 1] as u16
+    }
 }
 
-unsafe impl Send for RingSlice {}
-unsafe impl Sync for RingSlice {}
+//unsafe impl Send for RingSlice {}
+//unsafe impl Sync for RingSlice {}
 
 use std::convert::TryInto;
 macro_rules! define_read_number {
@@ -296,7 +302,6 @@ macro_rules! define_read_number {
 }
 
 impl RingSlice {
-    define_read_number!(read_u16, u16);
     define_read_number!(read_u32, u32);
     define_read_number!(read_u64, u64);
 }

--- a/endpoint/src/cacheservice/topo.rs
+++ b/endpoint/src/cacheservice/topo.rs
@@ -81,7 +81,7 @@ where
         if !req.operation().master_only() {
             let mut ctx = super::Context::from(*req.mut_context());
             let (i, try_next, write_back) = if req.operation().is_store() {
-                self.context_store(&mut ctx, req.try_next_type())
+                self.context_store(&mut ctx, &req)
             } else {
                 if !ctx.inited() {
                     // ctx未初始化, 是第一次读请求；仅第一次请求记录时间，原因如下：
@@ -113,11 +113,7 @@ where
     E: Endpoint<Item = Req>,
 {
     #[inline]
-    fn context_store(
-        &self,
-        ctx: &mut super::Context,
-        try_next_type: TryNextType,
-    ) -> (usize, bool, bool) {
+    fn context_store(&self, ctx: &mut super::Context, req: &Req) -> (usize, bool, bool) {
         let (idx, try_next, write_back);
         ctx.check_and_inited(true);
         if ctx.is_write() {
@@ -130,7 +126,8 @@ where
             try_next = if idx + 1 >= self.streams.len() {
                 false
             } else {
-                match try_next_type {
+                use protocol::memcache::Binary;
+                match req.try_next_type() {
                     TryNextType::NotTryNext => false,
                     TryNextType::TryNext => true,
                     TryNextType::Unkown => self.force_write_all,

--- a/endpoint/src/cacheservice/topo.rs
+++ b/endpoint/src/cacheservice/topo.rs
@@ -87,7 +87,7 @@ where
                     // ctx未初始化, 是第一次读请求；仅第一次请求记录时间，原因如下：
                     // 第一次读一般访问L1，miss之后再读master；
                     // 读quota的更新根据第一次的请求时间更合理
-                    if let Some(quota) = self.streams.quota(){
+                    if let Some(quota) = self.streams.quota() {
                         req.quota(quota);
                     }
                 }

--- a/endpoint/src/redisservice/topo.rs
+++ b/endpoint/src/redisservice/topo.rs
@@ -58,7 +58,7 @@ where
     fn send(&self, mut req: Self::Item) {
         debug_assert_ne!(self.shards.len(), 0);
 
-        let shard_idx = if req.sendto_all() {
+        let shard_idx = if req.ext().sendto_all() {
             //全节点分发请求
             let ctx = super::transmute(req.context_mut());
             let idx = ctx.shard_idx as usize;
@@ -75,9 +75,9 @@ where
         log::debug!("+++ {} send {} => {:?}", self.cfg.service, shard_idx, req);
 
         // 如果有从，并且是读请求，如果目标server异常，会重试其他slave节点
-        if shard.has_slave() && !req.operation().is_store() && !req.master_only() {
+        if shard.has_slave() && !req.operation().is_store() && !req.ext().master_only() {
             if *req.context_mut() == 0 {
-                if let Some(quota) = shard.slaves.quota(){
+                if let Some(quota) = shard.slaves.quota() {
                     req.quota(quota);
                 }
             }

--- a/endpoint/src/redisservice/topo.rs
+++ b/endpoint/src/redisservice/topo.rs
@@ -58,7 +58,7 @@ where
     fn send(&self, mut req: Self::Item) {
         debug_assert_ne!(self.shards.len(), 0);
 
-        let shard_idx = if req.ext().sendto_all() {
+        let shard_idx = if req.sendto_all() {
             //全节点分发请求
             let ctx = super::transmute(req.context_mut());
             let idx = ctx.shard_idx as usize;
@@ -75,7 +75,7 @@ where
         log::debug!("+++ {} send {} => {:?}", self.cfg.service, shard_idx, req);
 
         // 如果有从，并且是读请求，如果目标server异常，会重试其他slave节点
-        if shard.has_slave() && !req.operation().is_store() && !req.ext().master_only() {
+        if shard.has_slave() && !req.operation().is_store() && !req.master_only() {
             if *req.context_mut() == 0 {
                 if let Some(quota) = shard.slaves.quota() {
                     req.quota(quota);

--- a/log/Cargo.toml
+++ b/log/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 elog = { package = "log", version = "0.4.17" }
+#[cfg(feature = "enable-log")]
 log4rs = { version = "1.0.0", features = ["gzip"] }
 
 [features]

--- a/protocol/src/flag.rs
+++ b/protocol/src/flag.rs
@@ -3,7 +3,7 @@ use crate::{HashedCommand, OpCode, Operation};
 pub struct Flag {
     op_code: OpCode,
     op: Operation,
-    try_next_type: TryNextType,
+    //try_next_type: TryNextType,
     sentonly: bool,
     //status_ok: bool,
     noforward: bool,
@@ -68,15 +68,15 @@ impl Flag {
         }
     }
 
-    #[inline]
-    pub fn set_try_next_type(&mut self, try_type: TryNextType) {
-        self.try_next_type = try_type
-    }
+    //#[inline]
+    //pub fn set_try_next_type(&mut self, try_type: TryNextType) {
+    //    self.try_next_type = try_type
+    //}
 
-    #[inline]
-    pub fn try_next_type(&self) -> TryNextType {
-        self.try_next_type.clone()
-    }
+    //#[inline]
+    //pub fn try_next_type(&self) -> TryNextType {
+    //    self.try_next_type.clone()
+    //}
 
     #[inline]
     pub fn new() -> Self {

--- a/protocol/src/flag.rs
+++ b/protocol/src/flag.rs
@@ -5,9 +5,9 @@ pub struct Flag {
     op: Operation,
     try_next_type: TryNextType,
     sentonly: bool,
-    status_ok: bool,
+    //status_ok: bool,
     noforward: bool,
-    nil_converted: bool, //是否进行了nil转换，用于设置req的rsp是否进行了nil convert【部分multi请求需要】
+    //nil_converted: bool, //是否进行了nil转换，用于设置req的rsp是否进行了nil convert【部分multi请求需要】
     v: u64,
 }
 
@@ -51,16 +51,16 @@ impl Flag {
     pub fn new() -> Self {
         Self::default()
     }
-    #[inline]
-    pub fn set_status_ok(&mut self, ok: bool) -> &mut Self {
-        debug_assert_eq!(self.ok(), false);
-        self.status_ok = ok;
-        self
-    }
-    #[inline]
-    pub fn ok(&self) -> bool {
-        self.status_ok
-    }
+    //#[inline]
+    //pub fn set_status_ok(&mut self, ok: bool) -> &mut Self {
+    //    debug_assert_eq!(self.ok(), false);
+    //    self.status_ok = ok;
+    //    self
+    //}
+    //#[inline]
+    //pub fn ok(&self) -> bool {
+    //    self.status_ok
+    //}
     #[inline]
     pub fn set_sentonly(&mut self, sentonly: bool) -> &mut Self {
         self.sentonly = sentonly;
@@ -115,15 +115,15 @@ impl Flag {
     pub fn ext_mut(&mut self) -> &mut u64 {
         &mut self.v
     }
-    #[inline]
-    pub fn set_nil_convert(&mut self) -> &mut Self {
-        self.nil_converted = true;
-        self
-    }
-    #[inline]
-    pub fn nil_converted(&self) -> bool {
-        self.nil_converted
-    }
+    //#[inline]
+    //pub fn set_nil_convert(&mut self) -> &mut Self {
+    //    self.nil_converted = true;
+    //    self
+    //}
+    //#[inline]
+    //pub fn nil_converted(&self) -> bool {
+    //    self.nil_converted
+    //}
 }
 
 #[derive(Debug, Clone)]

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -4,6 +4,8 @@ mod packet;
 use packet::RespStatus::*;
 use packet::*;
 
+pub use packet::Binary;
+
 #[derive(Clone, Default)]
 pub struct MemcacheBinary;
 
@@ -37,7 +39,8 @@ impl Protocol for MemcacheBinary {
             let cmd = req.operation();
             let op_code = req.map_op(); // 把quite get请求，转换成单个的get请求
             let mut flag = Flag::from_op(op_code as u16, cmd);
-            flag.set_try_next_type(req.try_next_type());
+            // try_next_type在需要的时候直接通过Request读取即可。
+            //flag.set_try_next_type(req.try_next_type());
             flag.set_sentonly(req.sentonly());
             flag.set_noforward(req.noforward());
             let guard = data.take(packet_len);

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -54,7 +54,7 @@ impl Protocol for MemcacheBinary {
     #[inline]
     fn parse_response<S: Stream>(&self, data: &mut S) -> Result<Option<Command>> {
         log::debug!("+++ mc will parse rsp: {:?}", data.slice());
-        assert!(data.len() > 0, "rsp: {:?}", data.slice());
+        debug_assert!(data.len() > 0, "rsp: {:?}", data.slice());
         let len = data.len();
         if len >= HEADER_LEN {
             let r = data.slice();
@@ -128,7 +128,8 @@ impl Protocol for MemcacheBinary {
             }
 
             // 如果quite 请求没拿到数据，直接忽略
-            if QUITE_GET_TABLE[old_op_code as usize] == 1 && !rsp.ok() {
+            //if QUITE_GET_TABLE[old_op_code as usize] == 1 && !rsp.ok() {
+            if is_quiet_get(old_op_code as u8) && !rsp.ok() {
                 return Ok(());
             }
             log::debug!("+++ will write mc rsp:{:?}", rsp.data());

--- a/protocol/src/memcache/binary/packet.rs
+++ b/protocol/src/memcache/binary/packet.rs
@@ -92,12 +92,12 @@ pub(super) const NOREPLY_MAPPING: [u8; 128] = [
     0, 0, 0, 0, 0, 0, 0, 0, 0,
 ];
 // 哪些请求是不需要转发的. 比如noop请求，version, status, quit等请求。这些请求可以直接计算出response。
-pub(super) const NO_FORWARD_OPS: [u8; 128] = [
-    0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-];
+//pub(super) const NO_FORWARD_OPS: [u8; 128] = [
+//    0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+//    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//];
 
 // 请求完毕后，不考虑layer及其他配置，如果cmd失败,是否继续try_next:
 // (1) 0: not try next(对add/replace生效);  (2) 1: try next;  (3) 2:unkown (仅对set生效，注意提前考虑cas)
@@ -122,37 +122,45 @@ pub(super) const OP_SET: u8 = 0x01;
 pub(super) const OP_DEL: u8 = 0x04;
 pub(super) const OP_ADD: u8 = 0x02;
 
-//pub(super) const OP_CODE_GETK: u8 = 0x0c;
+pub(super) const OP_GETK: u8 = 0x0c;
 
 // 这个专门为gets扩展
 pub(super) const OP_GETS: u8 = 0x48;
 // 这个没有业务使用，先注销掉
-// pub(super) const OP_CODE_GETSQ: u8 = 0x49;
+pub(super) const OP_GETSQ: u8 = 0x49;
 
 // 0x09: getq
 // 0x0d: getkq
 // 0x49: getsq
-pub(super) const QUITE_GET_TABLE: [u8; 128] = [
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-];
+//pub(super) const QUITE_GET_TABLE: [u8; 128] = [
+//    0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//    0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//];
+#[inline(always)]
+pub(super) fn is_quiet_get(op_code: u8) -> bool {
+    match op_code {
+        OP_GETQ | OP_GETKQ | OP_GETSQ => true,
+        _ => false,
+    }
+    //QUITE_GET_TABLE[op_code as usize] == 1
+}
 
 // 在请求时，部分场景下把op_code进行一次映射。
 // 1. quite get请求映射成 non-quite get请求。
 //      getq(0x09) => get(0x00); getkq(0x0d) => getk(0x0c); 以实现multiget的pipeline
 // 2. 把gets(0x48), getsq(0x49) => get(0x00)请求。 // 支持gets请求只发送给master
-pub(super) const OPS_MAPPING_TABLE: [u8; 128] = [
-    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x0a, 0x0b, 0x0c, 0x0c, 0x0e, 0x0f,
-    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
-    0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
-    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
-    0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x00, 0x00, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f,
-    0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f,
-    0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f,
-    0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f,
-];
+//pub(super) const OPS_MAPPING_TABLE: [u8; 128] = [
+//    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x0a, 0x0b, 0x0c, 0x0c, 0x0e, 0x0f,
+//    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+//    0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
+//    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
+//    0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x00, 0x00, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f,
+//    0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f,
+//    0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f,
+//    0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f,
+//];
 
 pub trait Binary<T> {
     fn op(&self) -> u8;
@@ -203,7 +211,7 @@ impl Binary<RingSlice> for RingSlice {
     }
     #[inline(always)]
     fn extra_len(&self) -> u8 {
-        assert!(self.len() >= HEADER_LEN);
+        debug_assert!(self.len() >= HEADER_LEN);
         self.at(PacketPos::ExtrasLength as usize)
     }
     #[inline(always)]
@@ -230,7 +238,7 @@ impl Binary<RingSlice> for RingSlice {
     }
     #[inline(always)]
     fn packet_len(&self) -> usize {
-        assert!(self.len() >= HEADER_LEN);
+        debug_assert!(self.len() >= HEADER_LEN);
         self.total_body_len() as usize + HEADER_LEN
     }
     #[inline(always)]
@@ -275,7 +283,8 @@ impl Binary<RingSlice> for RingSlice {
     // 需要应对gek个各种姿势： getkq...getkq + noop, getkq...getkq + getk，对于quite cmd，肯定是multiget的非结尾请求
     #[inline(always)]
     fn quiet_get(&self) -> bool {
-        QUITE_GET_TABLE[self.op() as usize] == 1
+        is_quiet_get(self.op())
+        //QUITE_GET_TABLE[self.op() as usize] == 1
     }
     #[inline(always)]
     fn clear_cas(&mut self) {
@@ -289,10 +298,19 @@ impl Binary<RingSlice> for RingSlice {
         let op = self.op();
         NOREPLY_MAPPING[op as usize] == op
     }
+    // 在请求时，部分场景下把op_code进行一次映射。
+    // 1. quite get请求映射成 non-quite get请求。
+    //      getq(0x09) => get(0x00); getkq(0x0d) => getk(0x0c); 以实现multiget的pipeline
+    // 2. 把gets(0x48), getsq(0x49) => get(0x00)请求。 // 支持gets请求只发送给master
     #[inline(always)]
     fn map_op(&mut self) -> u8 {
         let old = self.op();
-        let new = OPS_MAPPING_TABLE[old as usize];
+        //let new = OPS_MAPPING_TABLE[old as usize];
+        let new = match old {
+            OP_GETQ | OP_GETS | OP_GETSQ => OP_GET,
+            OP_GETKQ => OP_GETK,
+            o => o,
+        };
         if new != old {
             self.update(PacketPos::Opcode as usize, new);
         }
@@ -317,7 +335,7 @@ impl Binary<RingSlice> for RingSlice {
             alg.hash(&key)
         } else {
             // 这些请求都是noforward请求，不会发送到backend
-            assert!(self.operation().is_meta() || self.noop());
+            debug_assert!(self.operation().is_meta() || self.noop());
             0
         }
     }
@@ -365,6 +383,10 @@ impl Binary<RingSlice> for RingSlice {
     }
     #[inline(always)]
     fn noforward(&self) -> bool {
-        NO_FORWARD_OPS[self.op() as usize] == 1
+        //NO_FORWARD_OPS[self.op() as usize] == 1
+        match self.op() {
+            OP_NOOP | OP_QUIT | OP_QUITQ | OP_VERSION | OP_STAT => true,
+            _ => false,
+        }
     }
 }

--- a/protocol/src/memcache/binary/packet.rs
+++ b/protocol/src/memcache/binary/packet.rs
@@ -154,7 +154,7 @@ pub(super) const OPS_MAPPING_TABLE: [u8; 128] = [
     0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f,
 ];
 
-pub(super) trait Binary<T> {
+pub trait Binary<T> {
     fn op(&self) -> u8;
     fn operation(&self) -> Operation;
     fn noop(&self) -> bool;

--- a/protocol/src/memcache/mod.rs
+++ b/protocol/src/memcache/mod.rs
@@ -1,6 +1,7 @@
 mod binary;
 //mod text;
 
+pub use binary::Binary;
 pub use binary::MemcacheBinary as MemcacheBin;
 pub use binary::MemcacheBinary;
 //pub use text::MemcacheText;

--- a/protocol/src/msgque/mcq/text/mod.rs
+++ b/protocol/src/msgque/mcq/text/mod.rs
@@ -32,7 +32,7 @@ impl McqText {
             let mut flag = Flag::from_op(cfg.op_code(), cfg.operation().clone());
 
             // mcq 总是需要重试，确保所有消息读写成功
-            flag.set_try_next_type(crate::TryNextType::TryNext);
+            //flag.set_try_next_type(crate::TryNextType::TryNext);
             // mcq 只需要写一次成功即可，不存在noreply(即只sent) req
             flag.set_sentonly(false);
             // 是否内部请求,不发往后端，如quit

--- a/protocol/src/msgque/mcq/text/mod.rs
+++ b/protocol/src/msgque/mcq/text/mod.rs
@@ -148,7 +148,7 @@ impl Protocol for McqText {
         if let Some(rsp) = response {
             // 不再创建local rsp，所有server响应的rsp data长度应该大于0
             debug_assert!(rsp.len() > 0, "req:{:?}, rsp:{:?}", request, rsp);
-            w.write_slice(rsp.data(), 0)?;
+            w.write_slice(rsp, 0)?;
             self.metrics(request, rsp, ctx);
         } else {
             let padding = cfg.get_padding_rsp();

--- a/protocol/src/msgque/mcq/text/mod.rs
+++ b/protocol/src/msgque/mcq/text/mod.rs
@@ -58,13 +58,13 @@ impl McqText {
         let mut packet = RspPacket::new(s);
         packet.parse()?;
 
-        let mut flag = Flag::new();
-        if packet.is_succeed() {
-            flag.set_status_ok(true);
-        }
+        //let mut flag = Flag::new();
+        //if packet.is_succeed() {
+        //    flag.set_status_ok(true);
+        //}
         let mem = packet.take();
         let _ = packet.delay_metric();
-        return Ok(Some(Command::new(flag, mem)));
+        return Ok(Some(Command::from(packet.is_succeed(), mem)));
     }
 
     // 协议内部的metric统计，全部放置于此

--- a/protocol/src/msgque/mcq/text/reqpacket.rs
+++ b/protocol/src/msgque/mcq/text/reqpacket.rs
@@ -290,10 +290,10 @@ impl<'a, S: crate::Stream> RequestPacket<'a, S> {
             .unwrap()
             .as_secs()
             .to_string();
-        let mut req_data: Vec<u8> = Vec::with_capacity(req_cmd.data().len() + time_sec.len());
+        let mut req_data: Vec<u8> = Vec::with_capacity(req_cmd.len() + time_sec.len());
 
         //前: flags前半部分
-        let pref_slice = req_cmd.data().sub_slice(0, self.flags_start - 0);
+        let pref_slice = req_cmd.sub_slice(0, self.flags_start - 0);
         pref_slice.copy_to_vec(&mut req_data);
 
         //中: 时间戳
@@ -301,7 +301,7 @@ impl<'a, S: crate::Stream> RequestPacket<'a, S> {
 
         // 后：flags 后半部分
         let oft = self.flags_start + self.flags_len;
-        let suffix_slice = req_cmd.data().sub_slice(oft, self.data.len() - oft);
+        let suffix_slice = req_cmd.sub_slice(oft, self.data.len() - oft);
         suffix_slice.copy_to_vec(&mut req_data);
 
         let marked_cmd = ds::MemGuard::from_vec(req_data);

--- a/protocol/src/parser.rs
+++ b/protocol/src/parser.rs
@@ -182,18 +182,18 @@ impl HashedCommand {
     pub fn update_hash(&mut self, idx_hash: i64) {
         self.hash = idx_hash;
     }
-    #[inline]
-    pub fn data(&self) -> &ds::RingSlice {
-        self.cmd.data()
-    }
-    #[inline]
-    pub fn data_mut(&mut self) -> &mut ds::RingSlice {
-        self.cmd.data_mut()
-    }
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.cmd.len()
-    }
+    //#[inline]
+    //pub fn data(&self) -> &ds::RingSlice {
+    //    self.cmd.data()
+    //}
+    //#[inline]
+    //pub fn data_mut(&mut self) -> &mut ds::RingSlice {
+    //    self.cmd.data_mut()
+    //}
+    //#[inline]
+    //pub fn len(&self) -> usize {
+    //    self.cmd.len()
+    //}
     #[inline]
     pub fn sentonly(&self) -> bool {
         self.flag.sentonly()

--- a/protocol/src/parser.rs
+++ b/protocol/src/parser.rs
@@ -215,8 +215,12 @@ impl HashedCommand {
         self.flag.noforward()
     }
     #[inline]
-    pub fn ext(&self) -> u64 {
-        self.flag.ext()
+    pub fn flag(&self) -> &Flag {
+        &self.flag
+    }
+    #[inline]
+    pub fn flag_mut(&mut self) -> &mut Flag {
+        &mut self.flag
     }
     #[inline]
     pub fn try_next_type(&self) -> TryNextType {

--- a/protocol/src/parser.rs
+++ b/protocol/src/parser.rs
@@ -102,10 +102,10 @@ pub struct HashedCommand {
 }
 
 impl Command {
-    #[inline]
-    pub fn new(flag: Flag, cmd: ds::MemGuard) -> Self {
-        Self { ok: flag.ok(), cmd }
-    }
+    //#[inline]
+    //pub fn new(flag: Flag, cmd: ds::MemGuard) -> Self {
+    //    Self { ok: flag.ok(), cmd }
+    //}
     #[inline]
     pub fn from(ok: bool, cmd: ds::MemGuard) -> Self {
         Self { ok, cmd }

--- a/protocol/src/parser.rs
+++ b/protocol/src/parser.rs
@@ -5,7 +5,7 @@ use sharding::hash::Hash;
 use crate::memcache::MemcacheBinary;
 use crate::msgque::MsgQue;
 use crate::redis::Redis;
-use crate::{Error, Flag, OpCode, Operation, Result, Stream, TryNextType, Writer};
+use crate::{Error, Flag, OpCode, Operation, Result, Stream, Writer};
 
 #[enum_dispatch(Proto)]
 #[derive(Clone)]
@@ -222,10 +222,10 @@ impl HashedCommand {
     pub fn flag_mut(&mut self) -> &mut Flag {
         &mut self.flag
     }
-    #[inline]
-    pub fn try_next_type(&self) -> TryNextType {
-        self.flag.try_next_type()
-    }
+    //#[inline]
+    //pub fn try_next_type(&self) -> TryNextType {
+    //    self.flag.try_next_type()
+    //}
 }
 //impl AsRef<Command> for HashedCommand {
 //    #[inline]

--- a/protocol/src/redis/command.rs
+++ b/protocol/src/redis/command.rs
@@ -190,7 +190,7 @@ impl CommandProperties {
         bulk_num: u16,
         first: bool,
         mut flag: Flag,
-        data: &RingSlice,
+        data: &MemGuard,
     ) -> HashedCommand {
         use ds::Buffer;
         //assert!(self.name.len() < 10, "name:{}", self.name);

--- a/protocol/src/redis/flag.rs
+++ b/protocol/src/redis/flag.rs
@@ -1,16 +1,15 @@
-// 0~15 bit : op_code
-const OP_CODE_BIT: u8 = 0;
-// 15~31: 16bit key count
-const KEY_COUNT_SHIFT: u8 = 0 + OP_CODE_BIT;
+// [0..16]: 16bit key count
+const KEY_COUNT_SHIFT: u8 = 0;
 const KEY_COUNT_BITS: u8 = 16;
 const KEY_COUNT_MASK: u64 = (1 << KEY_COUNT_BITS) - 1;
-// 32: 标识是否是第一个key
+// [16]: 标识是否是第一个key
 const MKEY_FIRST_SHIFT: u8 = KEY_COUNT_SHIFT + KEY_COUNT_BITS;
 const MKEY_FIRST_BIT: u8 = 1; // 这个先保留，后续增加字段时需要
-                              // 33: master_only
+
+// [17]: master_only
 const MASTER_ONLY_SHIFT: u8 = MKEY_FIRST_SHIFT + MKEY_FIRST_BIT;
 const MASTER_ONLY_BIT: u8 = 1;
-// 34: sendto_all
+// [18]: sendto_all
 const SENDTO_ALL_SHIFT: u8 = MASTER_ONLY_SHIFT + MASTER_ONLY_BIT;
 const _SENDTO_ALL_BIT: u8 = 1;
 

--- a/protocol/src/redis/flag.rs
+++ b/protocol/src/redis/flag.rs
@@ -1,5 +1,5 @@
 // 0~15 bit : op_code
-const OP_CODE_BIT: u8 = 16;
+const OP_CODE_BIT: u8 = 0;
 // 15~31: 16bit key count
 const KEY_COUNT_SHIFT: u8 = 0 + OP_CODE_BIT;
 const KEY_COUNT_BITS: u8 = 16;
@@ -37,8 +37,8 @@ pub trait RedisFlager {
     // fn token_count(&self) -> u8;
 }
 
-use crate::Bit;
-impl RedisFlager for u64 {
+use crate::{Bit, Ext};
+impl<T: Ext> RedisFlager for T {
     #[inline]
     fn set_key_count(&mut self, cnt: u16) {
         self.mask_set(KEY_COUNT_SHIFT, KEY_COUNT_MASK, cnt as u64)
@@ -49,9 +49,10 @@ impl RedisFlager for u64 {
     }
     #[inline]
     fn set_mkey_first(&mut self) {
-        assert!(!self.mkey_first());
-        *self |= 1 << MKEY_FIRST_SHIFT;
-        assert!(self.mkey_first());
+        debug_assert!(!self.mkey_first());
+        self.set(MKEY_FIRST_SHIFT);
+        //*self.ext_mut() |= 1 << MKEY_FIRST_SHIFT;
+        debug_assert!(self.mkey_first());
     }
     #[inline]
     fn mkey_first(&self) -> bool {

--- a/protocol/src/redis/mod.rs
+++ b/protocol/src/redis/mod.rs
@@ -51,7 +51,7 @@ impl Redis {
                         packet.ignore_one_bulk()?;
                     }
                     let kv = packet.take();
-                    let req = cfg.build_request(hash, bulk, first, flag, kv.data());
+                    let req = cfg.build_request(hash, bulk, first, flag, &kv);
                     process.process(req, packet.complete());
                 }
             } else {
@@ -265,7 +265,7 @@ impl Protocol for Redis {
         if !cfg.multi {
             // 非multi请求,有响应直接返回client，否则构建
             if let Some(rsp) = response {
-                w.write_slice(rsp.data(), 0)?;
+                w.write_slice(rsp, 0)?;
             } else {
                 // 无响应，则根据cmd name构建对应响应
                 match cfg.cmd_type {
@@ -301,7 +301,7 @@ impl Protocol for Redis {
                 // 如果rsp是ok，或者不需要bulk num，直接发送；否则构建rsp or padding rsp
                 if let Some(rsp) = response {
                     if rsp.ok() || !cfg.need_bulk_num {
-                        w.write_slice(rsp.data(), 0)?;
+                        w.write_slice(rsp, 0)?;
                         return Ok(());
                     }
                 }
@@ -437,7 +437,7 @@ impl Protocol for Redis {
     }
     #[inline(always)]
     fn check(&self, _req: &HashedCommand, _resp: &Command) {
-        if _resp.data()[0] == b'-' {
+        if _resp[0] == b'-' {
             log::error!("+++ check failed for req:{:?}, resp:{:?}", _req, _resp);
         }
     }

--- a/protocol/src/redis/mod.rs
+++ b/protocol/src/redis/mod.rs
@@ -289,12 +289,11 @@ impl Protocol for Redis {
         } else {
             // multi请求，如果需要bulk num，对第一个key先返回bulk head；
             // 对第一个key的响应都要返回，但对不需要bulk num的其他key响应，不需要返回，直接吞噬
-            let ext = request.ext();
-            let first = ext.mkey_first();
+            let first = request.mkey_first();
             if first || cfg.need_bulk_num {
                 if first && cfg.need_bulk_num {
                     w.write_u8(b'*')?;
-                    w.write_s_u16(ext.key_count())?;
+                    w.write_s_u16(request.key_count())?;
                     w.write(b"\r\n")?;
                 }
 

--- a/protocol/src/stream.rs
+++ b/protocol/src/stream.rs
@@ -1,3 +1,5 @@
+use ds::MemGuard;
+use std::ops::Deref;
 pub trait AsyncBufRead {
     fn poll_recv(&mut self, cx: &mut std::task::Context<'_>) -> std::task::Poll<crate::Result<()>>;
 }
@@ -41,8 +43,8 @@ pub trait Writer: ds::BufWriter + Sized {
     fn cache(&mut self, hint: bool);
 
     #[inline]
-    fn write_slice(&mut self, data: &ds::RingSlice, oft: usize) -> Result<()> {
-        data.copy_to(oft, self)?;
+    fn write_slice<S: Deref<Target = MemGuard>>(&mut self, data: &S, oft: usize) -> Result<()> {
+        (&*data).copy_to(oft, self)?;
         Ok(())
     }
     fn shrink(&mut self);

--- a/stream/src/handler.rs
+++ b/stream/src/handler.rs
@@ -115,7 +115,7 @@ where
         self.s.cache(self.data.has_multi());
         while let Some(req) = ready!(self.data.poll_recv(cx)) {
             self.num.tx();
-            self.s.write_slice(req.data(), 0)?;
+            self.s.write_slice(&*req, 0)?;
             match req.on_sent() {
                 Some(r) => self.pending.push_back((r, Instant::now())),
                 None => {

--- a/tests/src/redis.rs
+++ b/tests/src/redis.rs
@@ -52,7 +52,7 @@ mod redis_test {
         cmd.set_mkey_first();
         assert!(cmd.mkey_first());
         //mkey_first所在位
-        cmd.clear(32);
+        cmd.clear(16);
         assert!(!cmd.mkey_first());
         //对前面设置的flag没有影响
         assert!(cmd.master_only());

--- a/tests/src/redis.rs
+++ b/tests/src/redis.rs
@@ -52,7 +52,7 @@ mod redis_test {
         cmd.set_mkey_first();
         assert!(cmd.mkey_first());
         //mkey_first所在位
-        cmd.ext_mut().clear(32);
+        cmd.clear(32);
         assert!(!cmd.mkey_first());
         //对前面设置的flag没有影响
         assert!(cmd.master_only());

--- a/tests_integration/Cargo.toml
+++ b/tests_integration/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 rand = "0.8.4"
-rust-crypto = "0.2.36"
+#rust-crypto = "0.2.36"
 byteorder = "1.4.3"
 memcache = "0.16.0"
 assert-panic = "1.0.1"


### PR DESCRIPTION
优化：
- request: 删除多余的field定义
- request: 把deref定义到MemGuard上。方便后续扩展
- 隐藏RingSlice数据结构，对外统一暴露Request与Response
- Flag: 把ext同时定义到Flag与Request上
- mc: 将TryNextType定义到Request上，在需要的时候访问。
- redis flag: 去掉不必要的flag定义
- mc parser: 把部分映射关系由table调整为match
- 添加部分debug assert
- crate: 调整部分依赖包版本
- crate: 调整部分依赖包版本
- version: 全局开启local模式时，在版本号上添加相应标识
