### PR TITLE
【暂不merge】增加新的hash：bdkrsub

### DIFF
--- a/sharding/src/hash/bkdrsub.rs
+++ b/sharding/src/hash/bkdrsub.rs
@@ -1,0 +1,36 @@
+/// <pre>用于支持key中部分字符串做hashkey，且hash算法类似bkdr的hsh算法；
+/// key格式：abc#123_456，hashkey则是‘#’之后、‘_’之前的内容；
+/// 格式注意：'#'必需存在，'_'可能不存在，如果'_'不存在则'#'之后的全部是hashkey</pre>
+#[derive(Clone, Default, Debug)]
+pub struct Bkdrsub;
+
+impl super::Hash for Bkdrsub {
+    fn hash<S: super::HashKey>(&self, key: &S) -> i64 {
+        const SEED: i32 = 131; // 31 131 1313 13131 131313 etc..
+        const START_CHAR_VAL: u8 = '#' as u8;
+        const END_CHAR_VAL: u8 = '_' as u8;
+
+        let mut hash = 0_i32;
+        let mut found_start_char = false;
+        // 轮询key中‘#’之后、‘_’之前的部分hashkey，如果没有'_'则一直计算到最后
+        for i in 0..key.len() {
+            let c = key.at(i);
+            if found_start_char {
+                // hashkey 计算
+                if c != END_CHAR_VAL {
+                    hash = hash.wrapping_mul(SEED).wrapping_add(c as i32);
+                    continue;
+                }
+                // 找到'_'，hashkey计算完毕
+                break;
+            } else if c == START_CHAR_VAL {
+                found_start_char = true;
+                continue;
+            }
+            // 没有找到#，持续轮询下一个字节
+        }
+
+        hash = hash & 0x7FFFFFFF;
+        hash as i64
+    }
+}

--- a/sharding/src/hash/bkdrsub.rs
+++ b/sharding/src/hash/bkdrsub.rs
@@ -1,6 +1,6 @@
-/// <pre>用于支持key中部分字符串做hashkey，且hash算法类似bkdr的hsh算法；
+/// <pre>用于支持key中部分字符串做hashkey，且hash算法类似bkdr的hash算法；
 /// key格式：abc#123_456，hashkey则是‘#’之后、‘_’之前的内容；
-/// 格式注意：'#'必需存在，'_'可能不存在，如果'_'不存在则'#'之后的全部是hashkey</pre>
+/// 格式注意：'#'需要存在，否则hashkey为空；'_'可能不存在，如果'_'不存在，则'#'之后的全部是hashkey</pre>
 #[derive(Clone, Default, Debug)]
 pub struct Bkdrsub;
 

--- a/sharding/src/hash/mod.rs
+++ b/sharding/src/hash/mod.rs
@@ -1,4 +1,5 @@
 pub mod bkdr;
+pub mod bkdrsub;
 pub mod crc32;
 pub mod crc32local;
 pub mod lbcrc32local;
@@ -19,6 +20,8 @@ pub use rawcrc32local::Rawcrc32local;
 pub use rawsuffix::RawSuffix;
 
 use enum_dispatch::enum_dispatch;
+
+use self::bkdrsub::Bkdrsub;
 
 // 占位hash，主要用于兼容服务框架，供mq等业务使用
 pub const HASH_PADDING: &str = "padding";
@@ -61,6 +64,7 @@ pub enum Hasher {
     Padding(Padding),
     Raw(Raw), // redis raw, long型字符串直接用数字作为hash
     Bkdr(Bkdr),
+    Bkdrsub(Bkdrsub),
     Crc32(Crc32),
     Crc32Short(Crc32Short),         // mc short crc32
     Crc32Num(Crc32Num),             // crc32 for a hash key whick is a num,
@@ -106,6 +110,7 @@ impl Hasher {
             return match alg_parts[0] {
                 HASH_PADDING => Self::Padding(Default::default()),
                 "bkdr" => Self::Bkdr(Default::default()),
+                "bkdrsub" => Self::Bkdrsub(Default::default()),
                 "raw" => Self::Raw(Raw::from(Default::default())),
                 "crc32" => Self::Crc32(Default::default()),
                 "crc32local" => Self::Crc32local(Default::default()),

--- a/tests/src/all.rs
+++ b/tests/src/all.rs
@@ -17,8 +17,7 @@ mod arena;
 mod asserts;
 mod layout;
 // mod mysql;
+mod decrypt;
 mod mysql_strategy;
 mod ring_buffer;
 mod tx_buffer;
-mod decrypt;
-

--- a/tests/src/all.rs
+++ b/tests/src/all.rs
@@ -17,6 +17,7 @@ mod arena;
 mod asserts;
 mod layout;
 // mod mysql;
+mod bkdrsub;
 mod decrypt;
 mod mysql_strategy;
 mod ring_buffer;

--- a/tests/src/bkdrsub.rs
+++ b/tests/src/bkdrsub.rs
@@ -1,0 +1,74 @@
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+};
+
+use sharding::{
+    distribution::Distribute,
+    hash::{Hash, Hasher},
+};
+
+#[test]
+fn bkdrsub_one() {
+    let hasher = Hasher::from("bkdrsub");
+
+    let key1 = "mfh15d#3940964349989430";
+    let hash1 = hasher.hash(&key1.as_bytes());
+    println!("key:{}, hash:{}, idx:{}", key1, hash1, hash1 % 180);
+}
+
+// TODO 临时校验测试，按需打开
+//#[test]
+fn bkdrsub_dist() {
+    let path_base = "./redisKey";
+    let port_start = 59152;
+    let port_end = 59211;
+    let shards = 180;
+
+    let hasher = Hasher::from("bkdrsub");
+    let servers = vec!["padding".to_string(); shards];
+    let dist = Distribute::from("modula", &servers);
+    let mut idx = 0;
+    for p in port_start..port_end + 1 {
+        let file = format!("{}/port_{}.txt", path_base, p);
+        println!("will check bkdrsub file/{} with idx:{}", file, idx);
+        check_file(idx, &file, hasher.clone(), dist.clone());
+        idx += 1;
+    }
+}
+
+/// 从文件中读取所有key，进行hash、dist后，check这些key是否都落在该idx上
+fn check_file(idx: usize, file: &str, hasher: Hasher, dist: Distribute) {
+    let f = File::open(file).expect(format!("bkdrsub file [{}] not exists!", file).as_str());
+    let mut reader = BufReader::new(f);
+    let mut count = 0;
+    loop {
+        let mut line = String::with_capacity(128);
+        if let Ok(bytes) = reader.read_line(&mut line) {
+            if bytes == 0 {
+                // read EOF
+                println!("bkdrsub file/{} processed {} lines", file, count);
+                break;
+            }
+            // TODO 这些key的hash不配套
+            if line.starts_with("pkm") || line.contains(":") {
+                println!("ignore: {}", line);
+                continue;
+            }
+            let line = line.trim().trim_end_matches(",");
+            let hash = hasher.hash(&line.as_bytes());
+            let idx_line = dist.index(hash);
+            if idx_line != idx {
+                println!("line:{}, hash:{}, idx:{}", line, hash, idx_line);
+            }
+            assert_eq!(
+                idx, idx_line,
+                "line[{}] dist err: {}/{}",
+                line, idx, idx_line
+            );
+            count += 1;
+        } else {
+            break;
+        }
+    }
+}

--- a/tests/src/bkdrsub.rs
+++ b/tests/src/bkdrsub.rs
@@ -17,7 +17,7 @@ fn bkdrsub_one() {
     println!("key:{}, hash:{}, idx:{}", key1, hash1, hash1 % 180);
 }
 
-// TODO 临时校验测试，按需打开
+// TODO 临时批量文件的hash、dist校验测试，按需打开
 //#[test]
 fn bkdrsub_dist() {
     let path_base = "./redisKey";

--- a/tests/src/hash_test.rs
+++ b/tests/src/hash_test.rs
@@ -58,4 +58,19 @@ mod hash_test {
 
         println!("u8:{:b}", i);
     }
+
+    #[test]
+    fn bkdrsub() {
+        let hasher = Hasher::from("bkdrsub");
+
+        let key1 = "abc#12345678901234567";
+        let hash1 = hasher.hash(&key1.as_bytes());
+        println!("key:{}, hash:{}", key1, hash1);
+        assert_eq!(hash1, 1108486745);
+
+        let key2 = "abc#12345678901234567_123456";
+        let hash2 = hasher.hash(&key2.as_bytes());
+        println!("key:{}, hash:{}", key2, hash2);
+        assert_eq!(hash2, 1108486745);
+    }
 }


### PR DESCRIPTION
支持新hash：bdkrsub    
即以key中‘#’ 、‘_’之间的substring作为hashkey，进行类似bkdr的hash计算。