### PR TITLE
启动参数支持指定可用区

### DIFF
--- a/context/src/lib.rs
+++ b/context/src/lib.rs
@@ -104,6 +104,9 @@ pub struct ContextOption {
     #[clap(long, help("private key path"), default_value("/var/private_key.pem"))]
     pub key_path: String,
 
+    #[clap(long, help("region"), default_value(""))]
+    pub region: String,
+
     // api参数，目前只有这一个差异参数，先放这里
     #[clap(long, help("api whitelist host"), default_value("localhost"))]
     pub whitelist_host: String,

--- a/sharding/Cargo.toml
+++ b/sharding/Cargo.toml
@@ -12,6 +12,6 @@ ds = { path = "../ds" }
 discovery = { path = "../discovery" }
 metrics = { path = "../metrics" }
 log = { path = "../log" }
-
+context = { path = "../context" }
 
 rand = "0.8.4"

--- a/sharding/src/select/by_distance.rs
+++ b/sharding/src/select/by_distance.rs
@@ -66,14 +66,21 @@ impl<T: Addr> Distance<T> {
         assert_ne!(replicas.len(), 0);
         let mut me = Self::new();
 
+        // 资源启用可用区
         let len_local = if region_enabled {
             // 开启可用区，local_len是当前可用区资源实例副本长度；需求详见#658
             // 按distance选local
             // 1. 距离小于等于4为local
             // 2. local为0，则全部为local
-            let l = replicas.sort(Vec::new(), |d, _| {
-                d <= discovery::distance::DISTANCE_VAL_REGION
-            });
+            let l = replicas.sort_by_region(
+                Vec::new(),
+                context::get()
+                    .region
+                    .is_empty()
+                    .then(|| None)
+                    .unwrap_or_else(|| Some(context::get().region.as_str())),
+                |d, _| d <= discovery::distance::DISTANCE_VAL_REGION,
+            );
             if l == 0 {
                 log::warn!(
                     "too few instance in region:{} total:{}, {:?}",


### PR DESCRIPTION
1. breeze启动参数支持指定可用区，如果指定，取值限定为[cn1, cn2, cn3]
2. breeze启动时指定有效可用区，且redis资源配置启用可用区才生效
