### PR TITLE
清理前一版本临时保留MysqlError

### DIFF
--- a/protocol/src/error.rs
+++ b/protocol/src/error.rs
@@ -8,8 +8,6 @@ pub enum Error {
     Mcq(McqError),
     // 关闭连接前需要把（静态/动态）异常消息发出去
     FlushOnClose(Vec<u8>),
-    // TODO: 暂时保留，等endpoint merge完毕后再清理，避免merge冲突导致的ci测试问题
-    MysqlError(Vec<u8>),
     Eof,
     UnexpectedData,
     QueueClosed,


### PR DESCRIPTION
前一版本，为避免merge时的大量代码冲突（dev有代码搬迁），暂时保留Error::MysqlError；
目前已merge完毕，可以清理了。