### PR TITLE
【不merge】临时支持 retryqps

### DIFF
--- a/protocol/src/callback.rs
+++ b/protocol/src/callback.rs
@@ -2,7 +2,10 @@ use std::{
     mem::MaybeUninit,
     ptr::{self, NonNull},
     sync::{
-        atomic::{AtomicBool, AtomicU8, Ordering::*},
+        atomic::{
+            AtomicBool, AtomicU8,
+            Ordering::{self, *},
+        },
         Arc,
     },
 };
@@ -125,6 +128,12 @@ impl CallbackContext {
                 None
             }
         }
+    }
+
+    /// 返回该请求被重试的次数，默认是0
+    #[inline(always)]
+    pub fn tries(&self) -> usize {
+        self.tries.load(Ordering::Acquire) as usize
     }
 
     #[inline]

--- a/stream/src/metric.rs
+++ b/stream/src/metric.rs
@@ -56,7 +56,7 @@ macro_rules! define_metrics {
 }
 
 define_metrics!(
-    qps:    tx-tx, rx-rx, err-err, cps-cps, kps-kps, conn-conn, key-key, nilconvert-nilconvert, inconsist-inconsist;
+    qps:    tx-tx, rx-rx, err-err, cps-cps, kps-kps, conn-conn, key-key, nilconvert-nilconvert, inconsist-inconsist, retrykps-retrykps;
     num:    conn_num-conn, read-read, write-write, invalid_cmd-invalid_cmd, unsupport_cmd-unsupport_cmd;
     rtt:    avg-avg;
     ratio:  cache-hit

--- a/stream/src/pipeline.rs
+++ b/stream/src/pipeline.rs
@@ -185,6 +185,12 @@ where
                 client.cache(true);
             }
 
+            // check retry kps
+            let tries = ctx.tries();
+            if tries >= 1 {
+                *metrics.retrykps() += 1;
+            }
+
             *metrics.key() += 1;
             let mut response = ctx.take_response();
 


### PR DESCRIPTION
仅仅为临时测试的跟踪，不merge。