### PR TITLE
support doublebase

### DIFF
--- a/endpoint/src/cacheservice/mod.rs
+++ b/endpoint/src/cacheservice/mod.rs
@@ -9,7 +9,11 @@ struct Context {
     ctx: protocol::Context,
 }
 
+// 高16位的mask，供store、retrive两种cmds共享
 const H_MASK: u64 = 0xffff << 48;
+// store cmds的skip slave的bit位
+const STORE_SKIP_SLAVE: u64 = 0x1 << 16;
+
 impl Context {
     #[inline]
     fn from(ctx: protocol::Context) -> Self {
@@ -30,16 +34,30 @@ impl Context {
     fn is_write(&self) -> bool {
         self.ctx & (1 << 62) > 0
     }
-    // 获取idx，并将原有的idx+1
+    // 获取write操作的idx，并将原有的idx+1
     #[inline]
     fn take_write_idx(&mut self) -> u16 {
         let idx = self.ctx as u16;
         self.ctx += 1;
         idx
     }
-    // 低16位存储是下一次的idx
-    // 如果是写请求，低16位，是索引
-    // 如果是读请求，则
+
+    /// 对store类型，doublebase时，对于cas/casq/add/addq操作slave时，需要设置该bit，后面回写时，需要skip slave_idx
+    /// 本操作仅对store类型cmds生效
+    #[inline(always)]
+    fn set_skip_slave_4store(&mut self) {
+        assert!(self.is_write());
+        self.ctx |= STORE_SKIP_SLAVE;
+    }
+
+    /// 对store类型，回写时是否需要skip slave
+    #[inline(always)]
+    fn need_skip_slave_4store(&self) -> bool {
+        self.ctx & STORE_SKIP_SLAVE > 0
+    }
+
+    // 如果是写请求，低16位是写索引，第17个bit存放是否回写slave
+    // 如果是读请求，则最低16bits存访当前idx，访问下一层时，将前一次的idx向高位左移16bits
     #[inline]
     fn take_read_idx(&mut self) -> u16 {
         let mut low_48bit = self.low();

--- a/endpoint/src/cacheservice/topo.rs
+++ b/endpoint/src/cacheservice/topo.rs
@@ -100,7 +100,32 @@ where
     fn send(&self, mut req: Self::Item) {
         debug_assert!(self.streams.local_len() > 0);
 
+        // TODO 测试稳定后清理，预计2023.11.30后可清理 fishermen
         // let idx: usize = 0; // master
+        // if !req.operation().master_only() {
+        //     let mut ctx = super::Context::from(*req.mut_context());
+        //     let (i, try_next, write_back) = if req.operation().is_store() {
+        //         self.context_store(&mut ctx, &req)
+        //     } else {
+        //         if !ctx.inited() {
+        //             // ctx未初始化, 是第一次读请求；仅第一次请求记录时间，原因如下：
+        //             // 第一次读一般访问L1，miss之后再读master；
+        //             // 读quota的更新根据第一次的请求时间更合理
+        //             if let Some(quota) = self.streams.quota() {
+        //                 req.quota(quota);
+        //             }
+        //         }
+        //         self.context_get(&mut ctx)
+        //     };
+        //     req.try_next(try_next);
+        //     req.write_back(write_back);
+        //     *req.mut_context() = ctx.ctx;
+        //     idx = i;
+        //     if idx >= self.streams.len() {
+        //         req.on_err(protocol::Error::TopChanged);
+        //         return;
+        //     }
+        // }
         let mut ctx = super::Context::from(*req.mut_context());
         // 根据context、request 获取send的策略：mc pool索引，是否try next，是否回写
         let (idx, try_next, write_back) = self.get_send_strategy(&mut ctx, &mut req);

--- a/endpoint/src/cacheservice/topo.rs
+++ b/endpoint/src/cacheservice/topo.rs
@@ -135,8 +135,8 @@ where
             req.write_back(write_back);
             *req.mut_context() = ctx.ctx;
             if idx >= self.streams.len() {
-                req.on_err(protocol::Error::TopChanged);
                 log::warn!("+++ idx/{} top changed? {},req:{}", idx, self, req);
+                req.on_err(protocol::Error::TopChanged);
                 return;
             }
         }

--- a/endpoint/src/cacheservice/topo.rs
+++ b/endpoint/src/cacheservice/topo.rs
@@ -136,6 +136,7 @@ where
             *req.mut_context() = ctx.ctx;
             if idx >= self.streams.len() {
                 req.on_err(protocol::Error::TopChanged);
+                log::warn!("+++ idx/{} top changed? {},req:{}", idx, self, req);
                 return;
             }
         }

--- a/protocol/src/flag.rs
+++ b/protocol/src/flag.rs
@@ -101,22 +101,25 @@ impl Flag {
     //}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum TryNextType {
     NotTryNext = 0,
     TryNext = 1,
-    Unkown = 2,
+    Unknown = 2,
 }
+// 方便检索
+const TRY_NEXT_TABLE: [TryNextType; 3] = [
+    TryNextType::NotTryNext,
+    TryNextType::TryNext,
+    TryNextType::Unknown,
+];
 
-// (1) 0: not try next(对add/replace生效);  (2) 1: try next;  (3) 2:unkown (仅对set生效，注意提前考虑cas)
-impl TryNextType {
-    pub fn from(val: u8) -> Self {
-        match val {
-            0 => TryNextType::NotTryNext,
-            1 => TryNextType::TryNext,
-            2 => TryNextType::Unkown,
-            _ => panic!("unknow try next type"),
-        }
+impl From<u8> for TryNextType {
+    fn from(val: u8) -> Self {
+        let idx = val as usize;
+        assert!(idx < TRY_NEXT_TABLE.len(), "malformed tryNextType:{}", idx);
+
+        *TRY_NEXT_TABLE.get(idx).expect("malformed tryNextType")
     }
 }
 

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -16,6 +16,9 @@ use crate::{
 
 use sharding::hash::Hash;
 
+/// mc的master在内部结构存储时，idx为0，结构顺序为： master, master_l1, slave, slave_l1
+pub(crate) const MASTER_IDX: usize = 0;
+
 impl Protocol for MemcacheBinary {
     #[inline]
     fn config(&self) -> crate::Config {


### PR DESCRIPTION
一 支持doubleBase  说明如下：
1. gets
  + 1.1. master，失败就请求master_l1(目前不支持slave)；
2. cas
  + 2.1. 首选master，unique id冲突，则返回失败；
  + 2.2. 其他情况，即认为成功（只要有一个layer可用，），改为set写所有layers。
3. add
  + 3.1. 首先master回应失败，则认为失败；
  + 3.2. 其他场景，均认为成功（只要有一个layer可用）；
4. set
  + 4.2. 不管master是否成功，统统set其他层；

二 备注 
1. 如果要避免set受master异常节点影响，设置force_write_all 为true即可