### PR TITLE
可用区内资源数量监控

### DIFF
--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 log = { path = "../log" }
 ds = { path = "../ds" }
 metrics = { path = "../metrics" }
-context = { path = "../context" }
 
 url = "2.2.2"
 async-trait.workspace = true

--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 log = { path = "../log" }
 ds = { path = "../ds" }
 metrics = { path = "../metrics" }
+context = { path = "../context" }
 
 url = "2.2.2"
 async-trait.workspace = true

--- a/discovery/src/distance.rs
+++ b/discovery/src/distance.rs
@@ -499,18 +499,13 @@ impl BClass for &String {
 }
 
 // 本机的region，优先级：
-// 1. 启动参数/环境变量的region
-// 2. 本机IP对应的region
-// 3. 本机IP
-pub fn region() -> String {
-    if let Some(region) = context::get().region() {
-        return region.to_string();
-    }
-
+// 1. 本机IP对应的region
+// 2. 未知region，返回cnx
+pub fn host_region() -> String {
     let cal = unsafe { DISTANCE_CALCULATOR.get_unchecked().get() };
     if let Some(region) = cal.region() {
         return region.clone();
     }
 
-    return metrics::raw_local_ip().to_string();
+    return "cnx".to_string();
 }

--- a/discovery/src/distance.rs
+++ b/discovery/src/distance.rs
@@ -208,6 +208,9 @@ impl DistanceCalculator {
             }
         }
     }
+    pub fn region(&self) -> &Option<String> {
+        &self.local_region
+    }
 }
 
 pub trait Addr {
@@ -493,4 +496,21 @@ impl BClass for &String {
         }
         b
     }
+}
+
+// 本机的region，优先级：
+// 1. 启动参数/环境变量的region
+// 2. 本机IP对应的region
+// 3. 本机IP
+pub fn region() -> String {
+    if let Some(region) = context::get().region() {
+        return region.to_string();
+    }
+
+    let cal = unsafe { DISTANCE_CALCULATOR.get_unchecked().get() };
+    if let Some(region) = cal.region() {
+        return region.clone();
+    }
+
+    return metrics::raw_local_ip().to_string();
 }

--- a/endpoint/Cargo.toml
+++ b/endpoint/Cargo.toml
@@ -15,6 +15,7 @@ sharding = { path = "../sharding" }
 log = { path = "../log" }
 rt = { path = "../rt" }
 context = { path = "../context" }
+metrics = { path = "../metrics" }
 
 byteorder = "1.4.3"
 bytes = "1.0.1"

--- a/endpoint/src/redisservice/config.rs
+++ b/endpoint/src/redisservice/config.rs
@@ -104,4 +104,7 @@ impl RedisNamespace {
 
         true
     }
+    pub(super) fn resource_type(&self) -> &str {
+        self.basic.resource_type.as_str()
+    }
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -53,6 +53,17 @@ impl Metric {
             &mut *(self as *const _ as *mut _)
         }
     }
+    pub fn inited(&mut self) -> bool {
+        self.item.inited()
+    }
+    // num类型，若未初始化则尝试初始化；若已经初始化，则值清0
+    pub fn zero_num(&mut self) {
+        if !self.inited() {
+            self.try_inited();
+        } else {
+            self.item.data().zero_num();
+        }
+    }
 }
 impl<T: MetricData + Debug> AddAssign<T> for Metric {
     #[inline]

--- a/metrics/src/macros.rs
+++ b/metrics/src/macros.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 pub trait MetricData: Sized {
     fn incr_to(self, data: &ItemData);
     fn incr_to_cache(self, _id: &Arc<Id>) {}
+    fn zero(self, _data: &ItemData) {}
 }
 
 #[derive(Default, Debug)]
@@ -30,6 +31,13 @@ impl ItemData {
         assert!(self.id.t.is_num());
         self.inner.num.incr(num);
     }
+    #[inline]
+    pub fn zero_num(&self) {
+        assert!(self.id.t.is_num());
+        unsafe {
+            self.inner.num.zero();
+        }
+    }
 }
 use crate::ToNumber;
 impl<T: ToNumber> MetricData for T {
@@ -40,6 +48,10 @@ impl<T: ToNumber> MetricData for T {
     #[inline]
     fn incr_to_cache(self, id: &Arc<Id>) {
         crate::register_cache(id, self.int());
+    }
+    #[inline]
+    fn zero(self, data: &ItemData) {
+        data.zero_num();
     }
 }
 use ds::time::Duration;

--- a/metrics/src/types/host.rs
+++ b/metrics/src/types/host.rs
@@ -121,3 +121,14 @@ pub fn decr_task() {
 pub fn set_sockfile_failed(failed_count: usize) {
     SOCKFILE_FAILED.store(failed_count as i64, Relaxed);
 }
+
+// fn unchange_number_metric(region_enable:bool,len_region: u16, port: &str, rsname: &str, region: &str) {
+pub fn resource_num_metric(source: &str, namespace: &str, bip: &str, n: u16) {
+    let path = crate::Path::new(vec![source, namespace, bip]);
+    let mut metric = path.num("region_resource");
+    if metric.inited() {
+        metric.zero_num()
+    };
+
+    metric += n;
+}

--- a/metrics/src/types/mod.rs
+++ b/metrics/src/types/mod.rs
@@ -6,7 +6,7 @@ mod rtt;
 mod status;
 
 pub(crate) use host::*;
-pub use host::{decr_task, incr_task, set_sockfile_failed};
+pub use host::{decr_task, incr_task, resource_num_metric, set_sockfile_failed};
 pub(crate) use number::*;
 pub(crate) use qps::*;
 pub(crate) use ratio::*;

--- a/metrics/src/types/number.rs
+++ b/metrics/src/types/number.rs
@@ -55,6 +55,10 @@ impl Number {
     pub(crate) fn incr(&self, v: i64) {
         self.inner.incr(v);
     }
+    #[inline]
+    pub(crate) fn zero(&self) {
+        self.inner.zero();
+    }
 }
 
 pub trait ToNumber {

--- a/sharding/src/select/by_distance.rs
+++ b/sharding/src/select/by_distance.rs
@@ -31,7 +31,8 @@ impl BackendQuota {
 // 2. 其他资源，replicas长度与len_local相同
 #[derive(Clone)]
 pub struct Distance<T> {
-    len_local: u16,
+    len_local: u16,  // 实际使用的local实例数量
+    len_region: u16, // 通过排序计算出的可用区内的实例数量，len_region <= len_local
     backend_quota: bool,
     idx: Arc<AtomicUsize>,
     replicas: Vec<(T, BackendQuota)>,
@@ -40,6 +41,7 @@ impl<T: Addr> Distance<T> {
     pub fn new() -> Self {
         Self {
             len_local: 0,
+            len_region: 0,
             backend_quota: false,
             idx: Default::default(),
             replicas: Vec::new(),
@@ -72,11 +74,10 @@ impl<T: Addr> Distance<T> {
             // 按distance选local
             // 1. 距离小于等于4为local
             // 2. local为0，则全部为local
-            let l = replicas.sort_by_region(
-                Vec::new(),
-                context::get().region(),
-                |d, _| d <= discovery::distance::DISTANCE_VAL_REGION,
-            );
+            let l = replicas.sort_by_region(Vec::new(), context::get().region(), |d, _| {
+                d <= discovery::distance::DISTANCE_VAL_REGION
+            });
+            me.len_region = l as u16; // 可用区内的实例数量
             if l == 0 {
                 log::warn!(
                     "too few instance in region:{} total:{}, {:?}",
@@ -102,6 +103,9 @@ impl<T: Addr> Distance<T> {
         me.topn(len_local);
 
         me
+    }
+    pub fn len_region(&self) -> u16 {
+        self.len_region
     }
     #[inline]
     pub fn from(replicas: Vec<T>) -> Self {


### PR DESCRIPTION
与#383的区别是：#383采用全局变量+lock，只推0；本方案是开启可用区，则可用区内的资源数量都推，按资源/端口维度推监控