### PR TITLE
mc deleteq收到异常响应，不再断连接，改为忽略异常响应

### DIFF
--- a/tests_integration/src/redis/basic/shard.rs
+++ b/tests_integration/src/redis/basic/shard.rs
@@ -230,18 +230,14 @@ fn test_hashkey() {
 fn master_hashkeyq_1() {
     let argkey = function_name!();
     let mut con = get_conn(&RESTYPEWITHSLAVE.get_host());
-    let mut setted = false;
     for server in SERVERSWITHSLAVE {
         let mut con = get_conn(server[1]);
         if server[1].ends_with("56379") {
             assert_eq!(con.set(argkey, 1), Ok(true));
-            setted = true;
         } else {
             redis::cmd("DEL").arg(argkey).execute(&mut con);
         }
     }
-
-    assert!(setted, "setted false: {}", RESTYPEWITHSLAVE.get_host());
     assert_eq!(con.get(argkey), Ok(1));
     con.send_packed_command(&redis::cmd("master").get_packed_command())
         .expect("send err");

--- a/tests_integration/src/redis/basic/shard.rs
+++ b/tests_integration/src/redis/basic/shard.rs
@@ -230,14 +230,18 @@ fn test_hashkey() {
 fn master_hashkeyq_1() {
     let argkey = function_name!();
     let mut con = get_conn(&RESTYPEWITHSLAVE.get_host());
+    let mut setted = false;
     for server in SERVERSWITHSLAVE {
         let mut con = get_conn(server[1]);
         if server[1].ends_with("56379") {
             assert_eq!(con.set(argkey, 1), Ok(true));
+            setted = true;
         } else {
             redis::cmd("DEL").arg(argkey).execute(&mut con);
         }
     }
+
+    assert!(setted, "setted false: {}", RESTYPEWITHSLAVE.get_host());
     assert_eq!(con.get(argkey), Ok(1));
     con.send_packed_command(&redis::cmd("master").get_packed_command())
         .expect("send err");


### PR DESCRIPTION
deleteq 可能会返回异常，此时不需要断连接，直接忽略即可；     
deleteq 在kv不存在时，返回的异常： not-found  