### PR TITLE
优化top update、减少metrics Path的内存对象数量

### DIFF
--- a/discovery/src/update.rs
+++ b/discovery/src/update.rs
@@ -45,35 +45,36 @@ where
         // 降低tick的频率，便于快速从chann中接收新的服务。
         let period = Duration::from_secs(1);
         let cycle = (self.tick.as_secs_f64() / period.as_secs_f64()).ceil() as usize;
-        let mut cycle_i = 0usize;
         let mut tick = interval(period);
+        let mut tick_i = 0;
         self.cb.with_discovery(&self.discovery).await;
         let mut services = Services::new(&self.snapshot);
-        // 每个周期结束清理缓存
+        let mut need_load = false;
         loop {
             while let Ok((name, t)) = self.rx.try_recv() {
-                log::info!("receive new service: {}", name);
                 services.register(name, t, &self.discovery).await;
             }
-            cycle_i += 1;
+            let cycle_i = tick_i % cycle;
 
-            // 部分服务更新配置后，需要重新加载
-            if cycle_i <= cycle || cycle_i % cycle == 0 {
-                services.check_load().await;
-                if !self.cb.inited() || cycle_i % cycle == 0 {
-                    self.cb.with_discovery(&self.discovery).await;
-                }
-            }
-            let i = cycle_i % cycle;
-            // 更新部分
             for (idx, group) in services.groups.iter_mut().enumerate() {
-                if idx % cycle == i {
-                    group.refresh(&self.snapshot, &self.discovery).await;
+                let refreshed = if idx % cycle == cycle_i {
+                    group.refresh(&self.snapshot, &self.discovery).await
                 } else {
-                    group.refresh_new(&self.snapshot, &self.discovery).await;
-                }
+                    group.refresh_new(&self.snapshot, &self.discovery).await
+                };
+                // 有一个group的refresh返回true，则需要load。
+                need_load |= refreshed;
             }
-            // 更新新注册的
+            if need_load {
+                // 没有全部load完成，则需要继续load。
+                need_load = !services.check_load().await;
+            }
+            // tick_i < cycle时，每个tick都check，增加扫描的效率。
+            // tick_i >= cycle时，每个cycle的第一个tick才check，减少扫描的消耗。
+            if !self.cb.inited() || cycle_i == 0 {
+                self.cb.with_discovery(&self.discovery).await;
+            }
+            tick_i += 1;
             tick.tick().await;
         }
     }
@@ -92,10 +93,12 @@ impl<T: TopologyWrite> Services<T> {
             indices: HashMap::with_capacity(64),
         }
     }
-    async fn check_load(&mut self) {
-        for g in self.groups.iter_mut() {
-            g.load();
-        }
+    // 检查所有的namespace是否已经加载。
+    // true: 所有的namespace都已经加载。
+    // false: 有namespace没有加载。
+    async fn check_load(&mut self) -> bool {
+        // c & g.load()是按位与，而不是逻辑与。确保所有的group都已经加载。
+        self.groups.iter_mut().fold(true, |c, g| c & g.load())
     }
     fn get_group(&mut self, group: &str) -> Option<&mut ServiceGroup<T>> {
         let &idx = self.indices.get(group)?;
@@ -107,6 +110,7 @@ impl<T: TopologyWrite> Services<T> {
     // namespace是可选。
     // namespace之前的是group的路径，如：分隔符为'+'。
     async fn register<D: Discover>(&mut self, name: String, top: T, d: &D) {
+        log::info!("receive new service: {}", name);
         let group = name.split('+').last().expect("name");
         let mut group_namespace = group.split(':');
         let group = group_namespace.next().expect("group");
@@ -154,12 +158,18 @@ impl<T: TopologyWrite> ServiceGroup<T> {
         self.load_from_snapshot(snapshot).await;
         self.load_from_discover(snapshot, d).await;
     }
-    fn load(&mut self) {
+    // load所有的namespace。
+    // true: 表示load完成
+    // false: 表示后续需要继续load
+    fn load(&mut self) -> bool {
+        let mut completed = true;
         for s in &mut self.namespaces {
             if s.top.need_load() {
                 s.top.load();
+                completed &= !s.top.need_load();
             }
         }
+        completed
     }
     // 第一行是sig
     // 第二行是group name
@@ -226,18 +236,19 @@ impl<T: TopologyWrite> ServiceGroup<T> {
             Err(e) => log::error!("failed to get service: {}, {}", self.path, e),
         }
     }
-    async fn refresh_new<D: Discover>(&mut self, snapshot: &str, d: &D) {
+    async fn refresh_new<D: Discover>(&mut self, snapshot: &str, d: &D) -> bool {
         if self.cfg.len() == 0 {
             self.load_from_discover(snapshot, d).await;
         }
-        self.update_all(true);
+        self.update_all(true)
     }
-    async fn refresh<D: Discover>(&mut self, snapshot: &str, d: &D) {
+    async fn refresh<D: Discover>(&mut self, snapshot: &str, d: &D) -> bool {
         self.load_from_discover(snapshot, d).await;
-        self.update_all(false);
+        self.update_all(false)
     }
     // new: 只更新新注册的服务
-    fn update_all(&mut self, new: bool) {
+    // 返回是否可能有namespace更新
+    fn update_all(&mut self, new: bool) -> bool {
         if self.changed && self.namespaces.len() > 0 {
             let s = self.namespaces.first().expect("empty");
             self.cache = s
@@ -258,7 +269,9 @@ impl<T: TopologyWrite> ServiceGroup<T> {
                 }
             }
             self.changed = false;
+            return true;
         }
+        false
     }
     fn register(&mut self, ns: String, top: T) {
         assert!(self.namespaces.iter().find(|s| s.name == ns).is_none());

--- a/metrics/src/ip.rs
+++ b/metrics/src/ip.rs
@@ -1,11 +1,5 @@
 use once_cell::sync::OnceCell;
 
-pub(crate) const TARGET_SPLIT: u8 = b'/';
-#[inline]
-pub(crate) fn encode_addr(addr: &str) -> &str {
-    addr
-}
-
 // 通过建立一次连接获取本地通讯的IP
 static LOCAL_IP_BY_CONNECT: OnceCell<String> = OnceCell::new();
 static RAW_LOCAL_IP_BY_CONNECT: OnceCell<String> = OnceCell::new();

--- a/metrics/src/prometheus.rs
+++ b/metrics/src/prometheus.rs
@@ -12,7 +12,7 @@ impl Prometheus {
         Self {
             idx: 0,
             secs,
-            ext_buf: Default::default(),
+            ext_buf: Vec::with_capacity(1024),
             host: false,
             ext_oft: 0,
         }

--- a/stream/src/checker.rs
+++ b/stream/src/checker.rs
@@ -54,7 +54,8 @@ impl<P, Req> BackendChecker<P, Req> {
         P: Protocol,
         Req: Request,
     {
-        let path_addr = self.path.clone().push(&self.addr);
+        self.path.push(&self.addr);
+        let path_addr = &self.path;
         let mut be_conns = path_addr.qps("be_conn");
         let mut timeout = Path::base().qps("timeout");
         let mut reconn = crate::reconn::ReconnPolicy::new();


### PR DESCRIPTION
1. top update时，每个tick都check_load，直到所有的update load完成
2. metrics: 减少Path的内存对象数量