### PR TITLE
重构retry策略，将所有对应逻辑收归到协议context中

### DIFF
--- a/endpoint/src/cacheservice/topo.rs
+++ b/endpoint/src/cacheservice/topo.rs
@@ -1,7 +1,6 @@
 use crate::select::Distance;
 use crate::{Endpoint, Endpoints, Topology};
 use discovery::TopologyWrite;
-use protocol::memcache::Binary;
 use protocol::{Protocol, Request, Resource::Memcache};
 use sharding::hash::{Hash, HashKey, Hasher};
 
@@ -111,8 +110,10 @@ where
         };
         req.try_next(try_next);
         req.write_back(write_back);
-        // TODO 有点怪异，先实现，晚点调整，这个属性直接从request获取更佳？ fishermen
-        req.retry_on_rsp_notok(req.can_retry_on_rsp_notok());
+
+        // TODO 有点怪异，先实现，晚点调整，这个属性直接从request获取更佳？ 预计2024.6.1后可清理 fishermen
+        // req.retry_on_rsp_notok(req.can_retry_on_rsp_notok());
+
         *req.mut_context() = ctx.ctx;
         log::debug!("+++ request sent prepared:{} - {} {}", idx, req, self);
         assert!(idx < self.streams.len(), "{} {} => {:?}", idx, self, req);

--- a/endpoint/src/msgque/topo.rs
+++ b/endpoint/src/msgque/topo.rs
@@ -144,7 +144,9 @@ where
         };
 
         req.try_next(try_next);
-        req.retry_on_rsp_notok(true);
+        // TODO 设计原则：协议性质的属性，在构建时一次性设置，测试完毕后清理,预计2024.6.1后可清理 fishermen
+        // req.retry_on_rsp_notok(true);
+
         *req.mut_context() = ctx.ctx;
 
         log::debug!(

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -20,7 +20,7 @@ impl Protocol for MemcacheBinary {
     #[inline]
     fn config(&self) -> crate::Config {
         crate::Config {
-            retry_on_rsp_notok: true,
+            // retry_on_rsp_notok: true,
             ..Default::default()
         }
     }
@@ -189,6 +189,12 @@ impl Protocol for MemcacheBinary {
             self.build_write_back_inplace(ctx.request_mut());
             None
         }
+    }
+
+    /// 在收到notok的响应时，对cas/casq/add等指令不重试，其他指令需重试
+    #[inline]
+    fn retry_on_rsp_notok(&self, req: &HashedCommand) -> bool {
+        req.can_retry_on_rsp_notok()
     }
 }
 impl MemcacheBinary {

--- a/protocol/src/msgque/mod.rs
+++ b/protocol/src/msgque/mod.rs
@@ -170,6 +170,12 @@ impl Protocol for McqText {
             _ => 1,
         }
     }
+
+    /// 对于mq，不管什么指令，只要返回错误rsp，都需要重试
+    #[inline]
+    fn retry_on_rsp_notok(&self, _req: &HashedCommand) -> bool {
+        true
+    }
 }
 
 impl McqText {

--- a/protocol/src/parser.rs
+++ b/protocol/src/parser.rs
@@ -62,7 +62,7 @@ pub struct ResOption {
 pub struct Config {
     pub need_auth: bool,
     pub pipeline: bool,
-    pub retry_on_rsp_notok: bool,
+    // pub retry_on_rsp_notok: bool,
 }
 
 pub enum HandShake {
@@ -127,6 +127,13 @@ pub trait Proto: Unpin + Clone + Send + Sync + 'static {
     #[inline]
     fn max_tries(&self, _req_op: Operation) -> u8 {
         1_u8
+    }
+
+    /// 在收到的rsp为notok时，是否重试，默认都不重试；
+    /// precondition：得收到rsp，且rsp为notok；没收到响应，不属于该策略的处理范围
+    #[inline]
+    fn retry_on_rsp_notok(&self, _req: &HashedCommand) -> bool {
+        false
     }
 }
 

--- a/protocol/src/req.rs
+++ b/protocol/src/req.rs
@@ -63,8 +63,11 @@ pub trait Request:
     //fn is_write_back(&self) -> bool;
     // 请求失败后，topo层面是否允许进行重试
     fn try_next(&mut self, goon: bool);
+
+    // TODO 测试完毕后清理 fishermen
     // 请求失败后，协议层面是否允许进行重试
-    fn retry_on_rsp_notok(&mut self, retry: bool);
+    // fn retry_on_rsp_notok(&mut self, retry: bool);
+
     // 初始化quota
     fn quota(&mut self, quota: BackendQuota);
 }

--- a/protocol/src/request.rs
+++ b/protocol/src/request.rs
@@ -49,10 +49,10 @@ impl crate::Request for Request {
     fn try_next(&mut self, goon: bool) {
         self.ctx().try_next = goon;
     }
-    #[inline]
-    fn retry_on_rsp_notok(&mut self, retry: bool) {
-        self.ctx().retry_on_rsp_notok = retry;
-    }
+    // #[inline]
+    // fn retry_on_rsp_notok(&mut self, retry: bool) {
+    //     self.ctx().retry_on_rsp_notok = retry;
+    // }
     #[inline]
     fn quota(&mut self, quota: BackendQuota) {
         self.ctx().quota(quota);

--- a/stream/src/pipeline.rs
+++ b/stream/src/pipeline.rs
@@ -122,7 +122,7 @@ where
             top: &self.top,
             first: &mut self.first,
             arena: &mut self.arena,
-            retry_on_rsp_notok: self.parser.config().retry_on_rsp_notok,
+            // retry_on_rsp_notok: self.parser.config().retry_on_rsp_notok,
             parser: &self.parser,
         };
 
@@ -221,7 +221,7 @@ struct Visitor<'a, T, P> {
     parser: &'a P,
     first: &'a mut bool,
     arena: &'a mut CallbackContextArena,
-    retry_on_rsp_notok: bool,
+    // retry_on_rsp_notok: bool,
 }
 
 impl<'a, T: Topology<Item = Request> + TopologyCheck, P: Protocol> protocol::RequestProcessor
@@ -234,16 +234,10 @@ impl<'a, T: Topology<Item = Request> + TopologyCheck, P: Protocol> protocol::Req
         // 否则下一个请求是子请求。
         *self.first = last;
         let cb = self.top.callback();
-        let req_op = cmd.operation();
-        let ctx = self.arena.alloc(CallbackContext::new(
-            cmd,
-            self.waker,
-            cb,
-            first,
-            last,
-            self.retry_on_rsp_notok,
-            self.parser.max_tries(req_op),
-        ));
+        // let req_op = cmd.operation();
+        let ctx = self.arena.alloc(
+            CallbackContext::new(cmd, self.waker, cb, first, last).with_retry_strategy(self.parser),
+        );
         let mut ctx = CallbackContextPtr::from(ctx, self.arena);
 
         // pendding 会move走ctx，所以提前把req给封装好


### PR DESCRIPTION
将重试策略收归到协议context中，目前涉及两个变量：  
1. retry_on_rsp_notok；
2. max_tries。  