### PR TITLE
消除rust 1.78.0编译warn

### DIFF
--- a/protocol/src/kv/common/bitflags_ext.rs
+++ b/protocol/src/kv/common/bitflags_ext.rs
@@ -2,23 +2,23 @@
 pub trait Bitflags: Copy {
     type Repr: Copy + num_traits::PrimInt;
 
-    fn empty() -> Self;
+    // fn empty() -> Self;
     fn all() -> Self;
     fn bits(&self) -> Self::Repr;
-    fn from_bits(bits: Self::Repr) -> Option<Self>;
+    // fn from_bits(bits: Self::Repr) -> Option<Self>;
     fn from_bits_truncate(bits: Self::Repr) -> Self;
-    /// # Safety
-    ///
-    /// Safety requirements are defined by the [`bitflags!`] macro.
-    unsafe fn from_bits_unchecked(bits: Self::Repr) -> Self;
-    fn is_empty(&self) -> bool;
-    fn is_all(&self) -> bool;
-    fn intersects(&self, other: Self) -> bool;
-    fn contains(&self, other: Self) -> bool;
-    fn insert(&mut self, other: Self);
-    fn remove(&mut self, other: Self);
-    fn toggle(&mut self, other: Self);
-    fn set(&mut self, other: Self, value: bool);
+    // # Safety
+    //
+    // Safety requirements are defined by the [`bitflags!`] macro.
+    // unsafe fn from_bits_unchecked(bits: Self::Repr) -> Self;
+    // fn is_empty(&self) -> bool;
+    // fn is_all(&self) -> bool;
+    // fn intersects(&self, other: Self) -> bool;
+    // fn contains(&self, other: Self) -> bool;
+    // fn insert(&mut self, other: Self);
+    // fn remove(&mut self, other: Self);
+    // fn toggle(&mut self, other: Self);
+    // fn set(&mut self, other: Self, value: bool);
 }
 
 /// It's a wrapper for `bitflags::bitflags!` macro that also implements the `Bitflags` trait.
@@ -45,10 +45,10 @@ macro_rules! my_bitflags {
         impl $crate::kv::common::bitflags_ext::Bitflags for $name {
             type Repr = $ty;
 
-            #[inline]
-            fn empty() -> Self {
-                $name::empty()
-            }
+            // #[inline]
+            // fn empty() -> Self {
+            //     $name::empty()
+            // }
 
             #[inline]
             fn all() -> Self {
@@ -60,57 +60,57 @@ macro_rules! my_bitflags {
                 $name::bits(&self)
             }
 
-            #[inline]
-            fn from_bits(bits: Self::Repr) -> Option<Self> {
-                $name::from_bits(bits)
-            }
+            // #[inline]
+            // fn from_bits(bits: Self::Repr) -> Option<Self> {
+            //     $name::from_bits(bits)
+            // }
 
             #[inline]
             fn from_bits_truncate(bits: Self::Repr) -> Self {
                 $name::from_bits_truncate(bits)
             }
 
-            #[inline]
-            unsafe fn from_bits_unchecked(bits: Self::Repr) -> Self {
-                $name::from_bits_unchecked(bits)
-            }
+            // #[inline]
+            // unsafe fn from_bits_unchecked(bits: Self::Repr) -> Self {
+            //     $name::from_bits_unchecked(bits)
+            // }
 
-            #[inline]
-            fn is_empty(&self) -> bool {
-                $name::is_empty(self)
-            }
+            // #[inline]
+            // fn is_empty(&self) -> bool {
+            //     $name::is_empty(self)
+            // }
 
-            #[inline]
-            fn is_all(&self) -> bool {
-                $name::is_all(self)
-            }
+            // #[inline]
+            // fn is_all(&self) -> bool {
+            //     $name::is_all(self)
+            // }
 
-            #[inline]
-            fn intersects(&self, other: Self) -> bool {
-                $name::intersects(self, other)
-            }
+            // #[inline]
+            // fn intersects(&self, other: Self) -> bool {
+            //     $name::intersects(self, other)
+            // }
 
-            #[inline]
-            fn contains(&self, other: Self) -> bool {
-                $name::contains(self, other)
-            }
+            // #[inline]
+            // fn contains(&self, other: Self) -> bool {
+            //     $name::contains(self, other)
+            // }
 
-            #[inline]
-            fn insert(&mut self, other: Self) {
-                $name::insert(self, other)
-            }
-            #[inline]
-            fn remove(&mut self, other: Self) {
-                $name::remove(self, other)
-            }
-            #[inline]
-            fn toggle(&mut self, other: Self) {
-                $name::toggle(self, other)
-            }
-            #[inline]
-            fn set(&mut self, other: Self, value: bool) {
-                $name::set(self, other, value)
-            }
+            // #[inline]
+            // fn insert(&mut self, other: Self) {
+            //     $name::insert(self, other)
+            // }
+            // #[inline]
+            // fn remove(&mut self, other: Self) {
+            //     $name::remove(self, other)
+            // }
+            // #[inline]
+            // fn toggle(&mut self, other: Self) {
+            //     $name::toggle(self, other)
+            // }
+            // #[inline]
+            // fn set(&mut self, other: Self, value: bool) {
+            //     $name::set(self, other, value)
+            // }
         }
 
         impl Default for $name {

--- a/protocol/src/kv/common/io.rs
+++ b/protocol/src/kv/common/io.rs
@@ -1,4 +1,4 @@
-use byteorder::{LittleEndian as LE, ReadBytesExt, WriteBytesExt};
+use byteorder::{LittleEndian as LE, ReadBytesExt};
 use bytes::BufMut;
 use ds::{ByteOrder, RingSlice};
 // use sha1::digest::typenum::Minimum;
@@ -420,43 +420,43 @@ pub trait ReadMysqlExt: ReadBytesExt {
         }
     }
 
-    /// Reads MySql's length-encoded string.
-    fn read_lenenc_str(&mut self) -> io::Result<Vec<u8>> {
-        let len = self.read_lenenc_int()?;
-        let mut output = vec![0_u8; len as usize];
-        self.read_exact(&mut output)?;
-        Ok(output)
-    }
+    // Reads MySql's length-encoded string.
+    // fn read_lenenc_str(&mut self) -> io::Result<Vec<u8>> {
+    //     let len = self.read_lenenc_int()?;
+    //     let mut output = vec![0_u8; len as usize];
+    //     self.read_exact(&mut output)?;
+    //     Ok(output)
+    // }
 }
 
-pub trait WriteMysqlExt: WriteBytesExt {
-    /// Writes MySql's length-encoded integer.
-    fn write_lenenc_int(&mut self, x: u64) -> io::Result<u64> {
-        if x < 251 {
-            self.write_u8(x as u8)?;
-            Ok(1)
-        } else if x < 65_536 {
-            self.write_u8(0xFC)?;
-            self.write_uint::<LE>(x, 2)?;
-            Ok(3)
-        } else if x < 16_777_216 {
-            self.write_u8(0xFD)?;
-            self.write_uint::<LE>(x, 3)?;
-            Ok(4)
-        } else {
-            self.write_u8(0xFE)?;
-            self.write_uint::<LE>(x, 8)?;
-            Ok(9)
-        }
-    }
+// pub trait WriteMysqlExt: WriteBytesExt {
+//     /// Writes MySql's length-encoded integer.
+//     fn write_lenenc_int(&mut self, x: u64) -> io::Result<u64> {
+//         if x < 251 {
+//             self.write_u8(x as u8)?;
+//             Ok(1)
+//         } else if x < 65_536 {
+//             self.write_u8(0xFC)?;
+//             self.write_uint::<LE>(x, 2)?;
+//             Ok(3)
+//         } else if x < 16_777_216 {
+//             self.write_u8(0xFD)?;
+//             self.write_uint::<LE>(x, 3)?;
+//             Ok(4)
+//         } else {
+//             self.write_u8(0xFE)?;
+//             self.write_uint::<LE>(x, 8)?;
+//             Ok(9)
+//         }
+//     }
 
-    /// Writes MySql's length-encoded string.
-    fn write_lenenc_str(&mut self, bytes: &[u8]) -> io::Result<u64> {
-        let written = self.write_lenenc_int(bytes.len() as u64)?;
-        self.write_all(bytes)?;
-        Ok(written + bytes.len() as u64)
-    }
-}
+//     /// Writes MySql's length-encoded string.
+//     fn write_lenenc_str(&mut self, bytes: &[u8]) -> io::Result<u64> {
+//         let written = self.write_lenenc_int(bytes.len() as u64)?;
+//         self.write_all(bytes)?;
+//         Ok(written + bytes.len() as u64)
+//     }
+// }
 
 impl Display for ParseBuf {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -471,7 +471,7 @@ impl Display for ParseBuf {
 }
 
 impl<T> ReadMysqlExt for T where T: ReadBytesExt {}
-impl<T> WriteMysqlExt for T where T: WriteBytesExt {}
+// impl<T> WriteMysqlExt for T where T: WriteBytesExt {}
 
 #[cfg(test)]
 mod tests {

--- a/protocol/src/kv/common/query_result.rs
+++ b/protocol/src/kv/common/query_result.rs
@@ -3,7 +3,7 @@ use crate::{Command, Stream};
 
 pub use crate::kv::common::proto::{Binary, Text};
 
-use crate::kv::common::{io::ParseBuf, packets::OkPacket, row::RowDeserializer, value::ServerSide};
+use crate::kv::common::{io::ParseBuf, packets::OkPacket, row::RowDeserializer};
 use crate::kv::rsppacket::ResponsePacket;
 
 use std::{marker::PhantomData, sync::Arc};
@@ -21,41 +21,41 @@ pub enum Or<A, B> {
 
 /// Result set kind.
 pub(crate) trait Protocol: 'static + Send + Sync {
-    fn next<'a, S: Stream>(
-        rsp_packet: &'a mut ResponsePacket<'a, S>,
-        columns: Arc<[Column]>,
-    ) -> Result<Option<Row>>;
+    // fn next<'a, S: Stream>(
+    //     rsp_packet: &'a mut ResponsePacket<'a, S>,
+    //     columns: Arc<[Column]>,
+    // ) -> Result<Option<Row>>;
 }
 
 impl Protocol for Text {
-    fn next<'a, S: Stream>(
-        rsp_packet: &'a mut ResponsePacket<'a, S>,
-        columns: Arc<[Column]>,
-    ) -> Result<Option<Row>> {
-        match rsp_packet.next_row_packet()? {
-            Some(pld) => {
-                let row = ParseBuf::from(*pld).parse::<RowDeserializer<(), Text>>(columns)?;
-                Ok(Some(row.into()))
-            }
-            None => Ok(None),
-        }
-    }
+    // fn next<'a, S: Stream>(
+    //     rsp_packet: &'a mut ResponsePacket<'a, S>,
+    //     columns: Arc<[Column]>,
+    // ) -> Result<Option<Row>> {
+    //     match rsp_packet.next_row_packet()? {
+    //         Some(pld) => {
+    //             let row = ParseBuf::from(*pld).parse::<RowDeserializer<(), Text>>(columns)?;
+    //             Ok(Some(row.into()))
+    //         }
+    //         None => Ok(None),
+    //     }
+    // }
 }
 
 impl Protocol for Binary {
-    fn next<'a, S: Stream>(
-        rsp_packet: &'a mut ResponsePacket<'a, S>,
-        columns: Arc<[Column]>,
-    ) -> Result<Option<Row>> {
-        match rsp_packet.next_row_packet()? {
-            Some(pld) => {
-                let row =
-                    ParseBuf::from(*pld).parse::<RowDeserializer<ServerSide, Binary>>(columns)?;
-                Ok(Some(row.into()))
-            }
-            None => Ok(None),
-        }
-    }
+    // fn next<'a, S: Stream>(
+    //     rsp_packet: &'a mut ResponsePacket<'a, S>,
+    //     columns: Arc<[Column]>,
+    // ) -> Result<Option<Row>> {
+    //     match rsp_packet.next_row_packet()? {
+    //         Some(pld) => {
+    //             let row =
+    //                 ParseBuf::from(*pld).parse::<RowDeserializer<ServerSide, Binary>>(columns)?;
+    //             Ok(Some(row.into()))
+    //         }
+    //         None => Ok(None),
+    //     }
+    // }
 }
 
 /// State of a result set iterator.

--- a/protocol/src/kv/mod.rs
+++ b/protocol/src/kv/mod.rs
@@ -43,7 +43,7 @@ pub mod prelude {
     #[doc(inline)]
     pub use crate::kv::common::value::convert::{ConvIr, FromValue, ToValue};
 
-    /// Trait for protocol markers [`crate::Binary`] and [`crate::Text`].
+    // Trait for protocol markers [`crate::Binary`] and [`crate::Text`].
     pub(crate) trait Protocol: crate::kv::common::query_result::Protocol {}
 
     impl Protocol for crate::kv::common::proto::Binary {}

--- a/protocol/src/memcache/binary/packet.rs
+++ b/protocol/src/memcache/binary/packet.rs
@@ -206,7 +206,7 @@ pub trait Binary {
     fn noforward(&self) -> bool;
 }
 
-pub trait Op {}
+// pub trait Op {}
 
 use ds::RingSlice;
 impl Binary for RingSlice {


### PR DESCRIPTION
Rust官方正式发布 1.78.0之后，github CI编译报错。本次修改仅为了消除这些编译报错。