### PR TITLE
调整mcq读取策略

### DIFF
--- a/endpoint/src/msgque/mod.rs
+++ b/endpoint/src/msgque/mod.rs
@@ -81,7 +81,7 @@ pub trait WriteStrategy {
 
 pub trait ReadStrategy {
     fn new(reader_len: usize) -> Self;
-    fn get_read_idx(&self) -> usize;
+    fn get_read_idx(&self, first_read: bool) -> usize;
 }
 
 #[derive(Debug, Clone, Default)]

--- a/endpoint/src/msgque/mod.rs
+++ b/endpoint/src/msgque/mod.rs
@@ -61,6 +61,7 @@ impl Context {
         Some(idx as usize)
     }
 
+    /// 记录本次qid，retry时需要
     #[inline]
     fn update_qid(&mut self, qid: u16) {
         let lower = self.ctx as u8;
@@ -81,7 +82,7 @@ pub trait WriteStrategy {
 
 pub trait ReadStrategy {
     fn new(reader_len: usize) -> Self;
-    fn get_read_idx(&self, first_read: bool) -> usize;
+    fn get_read_idx(&self, last_idx: Option<usize>) -> usize;
 }
 
 #[derive(Debug, Clone, Default)]

--- a/endpoint/src/msgque/strategy/round_robbin.rs
+++ b/endpoint/src/msgque/strategy/round_robbin.rs
@@ -3,11 +3,14 @@ use std::fmt::{Display, Formatter};
 use crate::{msgque::ReadStrategy, CloneableAtomicUsize};
 use std::sync::atomic::Ordering::Relaxed;
 
+// 最大连续命中次数，超过该次数则重置命中次数
+const MAX_CONTINUE_HITS: usize = 100;
 /// 依次轮询队列列表，注意整个列表在初始化时需要进行随机乱序处理
 #[derive(Debug, Clone, Default)]
 pub struct RoundRobbin {
     que_len: usize,
     current_pos: CloneableAtomicUsize,
+    continue_hits: CloneableAtomicUsize,
 }
 
 impl ReadStrategy for RoundRobbin {
@@ -19,11 +22,24 @@ impl ReadStrategy for RoundRobbin {
             que_len: reader_len,
             // current_pos: Arc::new(AtomicUsize::new(rand)),
             current_pos: CloneableAtomicUsize::new(rand),
+            continue_hits: CloneableAtomicUsize::new(0),
         }
     }
     /// 实现策略很简单：持续轮询
     #[inline]
-    fn get_read_idx(&self) -> usize {
+    fn get_read_idx(&self, first_read: bool) -> usize {
+        // 主路径，第一次读
+        if first_read {
+            // 如果没有超过阀值，不进行轮询，只增加hits计数，
+            if self.continue_hits.load(ordering::Relaxed) <= MAX_CONTINUE_HITS {
+                self.continue_hits.fetch_add(1, ordering::Relaxed);
+                return self.current_pos.load(Relaxed);
+            }
+            // 读取次数超过阀值，重置hits次数
+            self.continue_hits.store(0, ordering::Relaxed);
+        }
+
+        // 持续命中次数超过阀值，或者重试读取，开始进行轮询下一个位置
         let pos = self.current_pos.fetch_add(1, Relaxed);
         pos.wrapping_rem(self.que_len)
     }

--- a/endpoint/src/msgque/topo.rs
+++ b/endpoint/src/msgque/topo.rs
@@ -128,7 +128,7 @@ where
         // 对于读请求：顺序读取队列，如果队列都去了到数据，就连续读N个，如果没读到，则尝试下一个ip，直到轮询完所有的ip
         // 注意空读后的最后一次请求，会概率尝试访问offline
         let (qid, try_next) = if req.operation().is_retrival() {
-            let qid = self.reader_strategy.get_read_idx();
+            let qid = self.reader_strategy.get_read_idx(count == 0);
             let try_next = (tried_count + 1) < self.backends.len();
             (qid, try_next)
         } else {

--- a/protocol/src/msgque/mod.rs
+++ b/protocol/src/msgque/mod.rs
@@ -25,6 +25,8 @@ impl Protocol for McqText {
         process: &mut P,
     ) -> Result<()> {
         let data = stream.slice();
+        log::debug!("+++ will parse req:{}", data);
+
         let mut oft = 0;
         while let Some(mut lfcr) = data.find_lf_cr(oft) {
             let head4 = data.u32_le(oft);
@@ -75,6 +77,7 @@ impl Protocol for McqText {
     #[inline]
     fn parse_response<S: Stream>(&self, stream: &mut S) -> Result<Option<Command>> {
         let data = stream.slice();
+        log::debug!("+++ will parse rsp:{}", data);
         let Some(mut lfcr) = data.find_lf_cr(0) else {
             return Ok(None);
         };

--- a/tests/src/mq/mod.rs
+++ b/tests/src/mq/mod.rs
@@ -5,6 +5,7 @@ use endpoint::msgque::strategy::Fixed;
 use endpoint::msgque::strategy::RoundRobbin;
 use endpoint::msgque::ReadStrategy;
 use endpoint::msgque::WriteStrategy;
+use rand::random;
 
 mod protocol;
 /// 轮询读取40次，预期把每个节点都读一遍
@@ -15,10 +16,12 @@ fn mq_read_strategy() {
 
     let mut count = 0;
     let mut readed = HashSet::with_capacity(READER_COUNT);
+    let mut last_idx = Some(random());
     loop {
         count += 1;
-        let idx = rstrategy.get_read_idx();
+        let idx = rstrategy.get_read_idx(last_idx);
         readed.insert(idx);
+        last_idx = Some(idx);
 
         if readed.len() == READER_COUNT {
             // println!("read strategy loop all: {}/{}", count, readed.len());

--- a/tests_integration/src/redis/mod.rs
+++ b/tests_integration/src/redis/mod.rs
@@ -201,7 +201,7 @@ fn test_mset_reenter() {
         assert_eq!(con.recv_response().unwrap(), redis::Value::Okay);
         let key = ("test_mset_reenter1", "test_mset_reenter2");
         assert_eq!(
-            con.mget::<(&str, &str), (usize, usize)>(key).unwrap(),
+            con.get::<(&str, &str), (usize, usize)>(key).unwrap(),
             (mid, mid)
         );
     }


### PR DESCRIPTION
灰度存在读堆积问题，原因跟当前策略有关：     
1. 单个ip灰度，单ip写对某个size的msg，会盯住某个mcq持续写；
2. 读会轮询读。
从而导致读写不匹配，进而产生堆积问题。   

解决对策：   
1. 打开整个服务池，读不堆积，则本策略暂不上线（服务池整体灰度后，有堆积）；
2. 打开整个服务池，如果读仍然堆积，则上该策略（已review&本地测试）。

遗留：
在写入机器远小于后端后端mcq时，仍然需要调整写策略（低优先级？）。