### PR TITLE
解决discovery时group冲突问题

### DIFF
--- a/discovery/src/update.rs
+++ b/discovery/src/update.rs
@@ -88,8 +88,8 @@ impl<T: TopologyWrite> Services<T> {
             indices: HashMap::with_capacity(64),
         }
     }
-    fn get_group(&mut self, group: &str) -> Option<&mut ServiceGroup<T>> {
-        let &idx = self.indices.get(group)?;
+    fn get_group(&mut self, full_group: &str) -> Option<&mut ServiceGroup<T>> {
+        let &idx = self.indices.get(full_group)?;
         assert!(idx < self.groups.len());
         Some(&mut self.groups[idx])
     }
@@ -102,20 +102,27 @@ impl<T: TopologyWrite> Services<T> {
         let group = name.split('+').last().expect("name");
         let mut group_namespace = group.split(':');
         let group = group_namespace.next().expect("group");
-        let (path, service) = match group_namespace.next() {
+        let (full_group, service) = match group_namespace.next() {
             Some(ns) => (&name[..name.len() - ns.len() - 1], ns),
             None => (name.as_str(), group),
         };
 
-        let g = match self.get_group(group) {
+        log::debug!(
+            "+++ in register full-group:{},service:{}, name:{}",
+            full_group,
+            service,
+            name
+        );
+        let g = match self.get_group(full_group) {
             Some(g) => g,
             None => {
                 let idx = self.groups.len();
-                let local = path.to_string();
-                let remote = path.replace('+', "/");
+                let local = full_group.to_string();
+                let remote = full_group.replace('+', "/");
+
                 self.groups
                     .push(ServiceGroup::new(group.to_string(), local, remote));
-                self.indices.insert(group.to_string(), idx);
+                self.indices.insert(full_group.to_string(), idx);
                 let g = self.groups.get_mut(idx).expect("not push");
                 assert_eq!(g.name, group);
                 g.init(&self.snapshot, d).await;
@@ -240,7 +247,10 @@ impl<T: TopologyWrite> ServiceGroup<T> {
                 .top
                 .disgroup(&self.name, &self.cfg)
                 .into_iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .map(|(k, v)| {
+                    log::debug!("+++ config key: {}, v:{}", k.to_string(), v.to_string());
+                    (k.to_string(), v.to_string())
+                })
                 .collect();
             for s in self.namespaces.iter_mut() {
                 // 如果是新注册的，则不更新

--- a/discovery/src/update.rs
+++ b/discovery/src/update.rs
@@ -107,12 +107,6 @@ impl<T: TopologyWrite> Services<T> {
             None => (name.as_str(), group),
         };
 
-        log::debug!(
-            "+++ in register full-group:{},service:{}, name:{}",
-            full_group,
-            service,
-            name
-        );
         let g = match self.get_group(full_group) {
             Some(g) => g,
             None => {
@@ -247,10 +241,7 @@ impl<T: TopologyWrite> ServiceGroup<T> {
                 .top
                 .disgroup(&self.name, &self.cfg)
                 .into_iter()
-                .map(|(k, v)| {
-                    log::debug!("+++ config key: {}, v:{}", k.to_string(), v.to_string());
-                    (k.to_string(), v.to_string())
-                })
+                .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect();
             for s in self.namespaces.iter_mut() {
                 // 如果是新注册的，则不更新


### PR DESCRIPTION
对于mc，group是all，不同业务可能存在冲突覆盖，导致端口无法监听，改为full group存储。