### PR TITLE
打印backend退出原因

### DIFF
--- a/protocol/src/kv/common/error/mod.rs
+++ b/protocol/src/kv/common/error/mod.rs
@@ -197,8 +197,8 @@ impl fmt::Display for Error {
             Error::UrlError(ref err) => write!(f, "UrlError {{ {} }}", err),
             #[cfg(any(feature = "native-tls", feature = "rustls"))]
             Error::TlsError(ref err) => write!(f, "TlsError {{ {} }}", err),
-            Error::FromRowError(_) => "from row conversion error".fmt(f),
-            Error::FromValueError(_) => "from value conversion error".fmt(f),
+            Error::FromRowError(ref _row) => "from row conversion error".fmt(f),
+            Error::FromValueError(ref _value) => "from value conversion error".fmt(f),
         }
     }
 }

--- a/protocol/src/vector/query_result.rs
+++ b/protocol/src/vector/query_result.rs
@@ -161,7 +161,7 @@ impl<T: crate::kv::prelude::Protocol> QueryResult<T> {
                     return Ok(None);
                 }
             },
-            InEmptySet(_) => {
+            InEmptySet(_a) => {
                 self.handle_next();
                 Ok(None)
             }

--- a/stream/src/checker.rs
+++ b/stream/src/checker.rs
@@ -105,13 +105,21 @@ impl<P, Req> BackendChecker<P, Req> {
             let handler = Handler::from(rx, stream, p, path_addr.clone());
             let handler = Entry::timeout(handler, Timeout::from(self.timeout.ms()));
             let ret = handler.await;
-            println!("backend error {:?} => {:?}", path_addr, ret);
+            println!(
+                "backend error {:?} => {:?} finish: {}",
+                path_addr,
+                ret,
+                self.finish.get()
+            );
             // handler 一定返回err，不会返回ok
             match ret.err().expect("handler return ok") {
                 Error::Eof | Error::IO(_) => {}
                 Error::Timeout(_t) => {
                     m_timeout += 1;
                     timeout += 1;
+                }
+                Error::ChanReadClosed => {
+                    debug_assert!(!self.finish.get(), "channel closed but not finish");
                 }
                 Error::UnexpectedData | _ => {
                     let mut unexpected_resp = Path::base().num("unexpected_resp");

--- a/stream/src/checker.rs
+++ b/stream/src/checker.rs
@@ -105,7 +105,7 @@ impl<P, Req> BackendChecker<P, Req> {
             let handler = Handler::from(rx, stream, p, path_addr.clone());
             let handler = Entry::timeout(handler, Timeout::from(self.timeout.ms()));
             let ret = handler.await;
-            log::error!("backend error {:?} => {:?}", path_addr, ret);
+            println!("backend error {:?} => {:?}", path_addr, ret);
             // handler 一定返回err，不会返回ok
             match ret.err().expect("handler return ok") {
                 Error::Eof | Error::IO(_) => {}


### PR DESCRIPTION
线上同一个服务池不同实例间unexpected_resp监控数量不一致，需要输出log进一步分析；后续再将本commit revert掉。