### PR TITLE
redis响应类型为字符串时，如果未完整接收，返回ProtocolIncomplete

### DIFF
--- a/protocol/src/redis/mod.rs
+++ b/protocol/src/redis/mod.rs
@@ -86,7 +86,11 @@ impl Redis {
             _ => return Err(RedisError::RespInvalid.into()),
         }
 
-        Ok((*oft <= data.len()).then(|| Command::from_ok(s.take(*oft))))
+        match *oft <= data.len() {
+            true => Ok(Some(Command::from_ok(s.take(*oft)))),
+            false => Err(Error::ProtocolIncomplete),
+        }
+        // Ok((*oft <= data.len()).then(|| Command::from_ok(s.take(*oft))))
     }
 }
 


### PR DESCRIPTION
第84行解析响应消息类型为字符串，当返回成功时，字符串内容不一定完成接收