### PR TITLE
在写改为轮询写后，读去掉盯读，且在miss后不重试

### DIFF
--- a/endpoint/src/msgque/strategy/round_robbin.rs
+++ b/endpoint/src/msgque/strategy/round_robbin.rs
@@ -3,13 +3,14 @@ use std::fmt::{Display, Formatter};
 use crate::{msgque::ReadStrategy, CloneableAtomicUsize};
 use std::sync::atomic::Ordering::Relaxed;
 
-const HITS_BITS: u32 = 8;
+// const HITS_BITS: u32 = 8;
 
 /// 依次轮询队列列表，注意整个列表在初始化时需要进行随机乱序处理
 #[derive(Debug, Clone, Default)]
 pub struct RoundRobbin {
     que_len: usize,
     // 低8bits放连续hits次数，其他bits放索引位置
+    // TODO 写改为轮询写，读也对应改为轮询读，同时miss后不重试，看效果 fishermen
     current_pos: CloneableAtomicUsize,
 }
 
@@ -25,23 +26,24 @@ impl ReadStrategy for RoundRobbin {
     }
     /// 实现策略很简单：持续轮询
     #[inline]
-    fn get_read_idx(&self, last_idx: Option<usize>) -> usize {
+    fn get_read_idx(&self, _last_idx: Option<usize>) -> usize {
         let origin_pos = self.current_pos.fetch_add(1, Relaxed);
-        let pos = match last_idx {
-            None => origin_pos,
-            Some(lidx) => {
-                // 将pos向后移动一个位置，如果已经被移动了，则不再移动
-                if lidx == origin_pos.que_idx(self.que_len) {
-                    let new_pos = (lidx + 1).pos();
-                    self.current_pos.store(new_pos, Relaxed);
-                    new_pos
-                } else {
-                    origin_pos
-                }
-            }
-        };
+        origin_pos.wrapping_rem(self.que_len)
+        // let pos = match last_idx {
+        //     None => origin_pos,
+        //     Some(lidx) => {
+        //         // 将pos向后移动一个位置，如果已经被移动了，则不再移动
+        //         if lidx == origin_pos.que_idx(self.que_len) {
+        //             let new_pos = (lidx + 1).pos();
+        //             self.current_pos.store(new_pos, Relaxed);
+        //             new_pos
+        //         } else {
+        //             origin_pos
+        //         }
+        //     }
+        // };
 
-        pos.que_idx(self.que_len)
+        // pos.que_idx(self.que_len)
     }
 }
 
@@ -56,24 +58,24 @@ impl Display for RoundRobbin {
     }
 }
 
-/// pos：低8位为单个idx的持续读取计数，高56位为队列的idx序号
-trait Pos {
-    fn que_idx(&self, que_len: usize) -> usize;
-}
+// /// pos：低8位为单个idx的持续读取计数，高56位为队列的idx序号
+// trait Pos {
+//     fn que_idx(&self, que_len: usize) -> usize;
+// }
 
-impl Pos for usize {
-    fn que_idx(&self, que_len: usize) -> usize {
-        self.wrapping_shr(HITS_BITS).wrapping_rem(que_len)
-    }
-}
+// impl Pos for usize {
+//     fn que_idx(&self, que_len: usize) -> usize {
+//         self.wrapping_shr(HITS_BITS).wrapping_rem(que_len)
+//     }
+// }
 
-/// idx是队列的idx序号，通过将idx左移8位来构建一个新的pos
-trait Idx {
-    fn pos(&self) -> usize;
-}
+// /// idx是队列的idx序号，通过将idx左移8位来构建一个新的pos
+// trait Idx {
+//     fn pos(&self) -> usize;
+// }
 
-impl Idx for usize {
-    fn pos(&self) -> usize {
-        self.wrapping_shl(HITS_BITS)
-    }
-}
+// impl Idx for usize {
+//     fn pos(&self) -> usize {
+//         self.wrapping_shl(HITS_BITS)
+//     }
+// }

--- a/protocol/src/msgque/mod.rs
+++ b/protocol/src/msgque/mod.rs
@@ -85,7 +85,7 @@ impl Protocol for MsgQue {
         }
         let head4 = data.u32_le(0);
         let ok = match head4 {
-            END => false,
+            END => true, // TODO get miss 后，不重试，因为写已经改为了轮询写，每个节点概率相同，观察效果 fishermen
             VALUE => {
                 // VALUE <key> <flags> <bytes> [<cas unique>]\r\n
                 let val_len = Self::val_len(data, 4, lfcr)?;

--- a/tests_integration/src/mq/mod.rs
+++ b/tests_integration/src/mq/mod.rs
@@ -10,7 +10,7 @@ fn msgque_both_write_read() {
 
     let key = "k2";
     let count = 5;
-    const QSIZES: [usize; 2] = [512, 4096];
+    const QSIZES: [usize; 2] = [512, 8192];
 
     for i in 0..count {
         let msg_len = QSIZES[i % QSIZES.len()] * 8 / 10;
@@ -25,7 +25,7 @@ fn msgque_both_write_read() {
     loop {
         let msg: Option<String> = mq_client.get(key).unwrap();
         read_count += 1;
-        if read_count >= 2 * count {
+        if read_count >= 5 * count {
             println!(
                 "stop for may read all mq msgs count:{}/{}",
                 hits, read_count
@@ -117,11 +117,11 @@ fn msgque_strategy_check() {
     for i in 0..count {
         let msg_len = QSIZES[i % QSIZES.len()] * 8 / 10;
         let value = build_msg(msg_len);
-        println!("will set mcq msg {} with len:{}", i, value.len());
+        println!("strategy will set mcq msg {} with len:{}", i, value.len());
         mq_client.set(key, value, 0).unwrap();
     }
 
-    println!("mq write {} msgs done", count);
+    println!("strategy mq write {} msgs done", count);
     let mut read_count = 0;
     let mut hits = 0;
     loop {
@@ -134,24 +134,24 @@ fn msgque_strategy_check() {
         if msg.is_some() {
             hits += 1;
             println!(
-                "mq len/{}, hits:{}/{}",
+                "strategy mq len/{}, hits:{}/{}",
                 msg.unwrap().len(),
                 hits,
                 read_count
             );
             if hits >= count {
-                println!("read all mq msgs count:{}/{}", hits, read_count);
+                println!("strategy read all mq msgs count:{}/{}", hits, read_count);
                 break;
             }
         } else {
-            println!("read empty for key: {}", key);
+            println!("strategy read empty for key: {}", key);
         }
     }
 
     // let hits_percent = (hits as f64) / (read_count as f64);
     // assert!(
     //     hits_percent >= 0.8,
-    //     "check read strategy:{}/{}",
+    //     "strategy check read strategy:{}/{}",
     //     hits,
     //     read_count
     // );


### PR DESCRIPTION
降低读频率，验证效果