### PR TITLE
后端资源超时时间允许最小20ms

### DIFF
--- a/endpoint/src/lib.rs
+++ b/endpoint/src/lib.rs
@@ -39,7 +39,7 @@ impl Timeout {
         me
     }
     pub fn adjust(&mut self, ms: u32) {
-        self.ms = ms.max(100).min(6000) as u16;
+        self.ms = ms.max(20).min(6000) as u16;
     }
     pub fn to(mut self, ms: u32) -> Self {
         if ms > 0 {

--- a/endpoint/src/lib.rs
+++ b/endpoint/src/lib.rs
@@ -24,6 +24,8 @@ const TO_MYSQL_S: Timeout = Timeout::from_millis(500);
 const TO_VECTOR_M: Timeout = Timeout::from_millis(1000);
 const TO_VECTOR_S: Timeout = Timeout::from_millis(500);
 const TO_UUID: Timeout = Timeout::from_millis(100);
+const TO_MIN_MS: u32 = 20;  // timeout最小值，单位ms
+const TO_MAX_MS: u32 = 6000; // timeout最大值，单位ms
 
 #[derive(Copy, Clone, Debug)]
 pub struct Timeout {
@@ -39,7 +41,7 @@ impl Timeout {
         me
     }
     pub fn adjust(&mut self, ms: u32) {
-        self.ms = ms.max(20).min(6000) as u16;
+        self.ms = ms.max(TO_MIN_MS).min(TO_MAX_MS) as u16;
     }
     pub fn to(mut self, ms: u32) -> Self {
         if ms > 0 {


### PR DESCRIPTION
特殊业务需要较小的超时时间，目前配置里的超时时间也是20ms