### PR TITLE
kv 不统计err req

### DIFF
--- a/protocol/src/kv/mod.rs
+++ b/protocol/src/kv/mod.rs
@@ -25,11 +25,11 @@ use super::Flag;
 use super::Protocol;
 use crate::kv::client::Client;
 use crate::kv::error::Error;
-use crate::Command;
 use crate::HandShake;
 use crate::HashedCommand;
 use crate::RequestProcessor;
 use crate::Stream;
+use crate::{Command, Operation};
 use ds::RingSlice;
 
 use sharding::hash::Hash;
@@ -251,10 +251,13 @@ impl Protocol for Kv {
         None
     }
 
-    // kv目前也不统计error，因为kv走mc binary协议，error基本都是get miss这种，不需要统计
+    // kv走mc binary协议，get miss属于error不统计，只统计上行请求
     #[inline]
-    fn metric_err(&self) -> bool {
-        false
+    fn metric_err(&self, req_op: Operation) -> bool {
+        match req_op {
+            Operation::Store => true,
+            _ => false,
+        }
     }
 }
 

--- a/protocol/src/kv/mod.rs
+++ b/protocol/src/kv/mod.rs
@@ -250,6 +250,12 @@ impl Protocol for Kv {
     {
         None
     }
+
+    // kv目前也不统计error，因为kv走mc binary协议，error基本都是get miss这种，不需要统计
+    #[inline]
+    fn metric_err(&self) -> bool {
+        false
+    }
 }
 
 impl Kv {

--- a/protocol/src/memcache/binary/mod.rs
+++ b/protocol/src/memcache/binary/mod.rs
@@ -10,8 +10,8 @@ pub use packet::Binary;
 pub struct MemcacheBinary;
 
 use crate::{
-    Command, Commander, Error, Flag, HashedCommand, Metric, MetricItem, Protocol, RequestProcessor,
-    Result, Stream, Writer,
+    Command, Commander, Error, Flag, HashedCommand, Metric, MetricItem, Operation, Protocol,
+    RequestProcessor, Result, Stream, Writer,
 };
 
 use sharding::hash::Hash;
@@ -193,7 +193,7 @@ impl Protocol for MemcacheBinary {
 
     // mc目前不需要统计error，因为mc的error基本都是get miss，del not-found这种，这种错误不需要统计
     #[inline]
-    fn metric_err(&self) -> bool {
+    fn metric_err(&self, _req_op: Operation) -> bool {
         false
     }
 }

--- a/protocol/src/parser.rs
+++ b/protocol/src/parser.rs
@@ -129,7 +129,7 @@ pub trait Proto: Unpin + Clone + Send + Sync + 'static {
         1_u8
     }
 
-    fn metric_err(&self) -> bool {
+    fn metric_err(&self, _req_op: Operation) -> bool {
         true
     }
 }

--- a/sharding/src/hash/mod.rs
+++ b/sharding/src/hash/mod.rs
@@ -25,8 +25,8 @@ pub use rawsuffix::RawSuffix;
 
 pub mod crc;
 
-use enum_dispatch::enum_dispatch;
 use self::{bkdrsub::Bkdrsub, crc64::Crc64, fnv1::Fnv1F32, fnv1::Fnv1aF64};
+use enum_dispatch::enum_dispatch;
 
 // 占位hash，主要用于兼容服务框架，供mq等业务使用
 pub const HASH_PADDING: &str = "padding";

--- a/stream/src/handler.rs
+++ b/stream/src/handler.rs
@@ -147,7 +147,7 @@ where
                 self.num.rx();
                 // 统计请求耗时、异常响应
                 self.rtt += start.elapsed();
-                if self.parser.metric_err() && !cmd.ok() {
+                if self.parser.metric_err(req.operation()) && !cmd.ok() {
                     self.err += 1;
                 }
 

--- a/stream/src/pipeline.rs
+++ b/stream/src/pipeline.rs
@@ -179,7 +179,7 @@ where
                 }
 
                 // 不区分是否last，这样更精确的感知总的异常响应数量
-                if self.parser.metric_err() && !rsp_ok {
+                if self.parser.metric_err(op) && !rsp_ok {
                     *self.metrics.err() += 1;
                 }
             }


### PR DESCRIPTION
kv 在sdk交互时走mc binary协议，get miss 这种get类型的error不统计，只统计store类型的error