### PR TITLE
style: format Rust sources

### DIFF
--- a/agent/src/init.rs
+++ b/agent/src/init.rs
@@ -68,7 +68,7 @@ pub(crate) fn start_metrics_register_task(_ctx: &Context) {
     rt::spawn(metrics::MetricRegister::default());
 }
 
-use tokio::signal::unix::{signal, SignalKind};
+use tokio::signal::unix::{SignalKind, signal};
 fn init_signal() {
     let stream = signal(SignalKind::terminate());
     match stream {

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -9,7 +9,7 @@ use context::Context;
 use discovery::*;
 mod init;
 
-use ds::time::{sleep, Duration};
+use ds::time::{Duration, sleep};
 use rt::spawn;
 
 use protocol::Result;

--- a/agent/src/prometheus.rs
+++ b/agent/src/prometheus.rs
@@ -1,8 +1,8 @@
 use metrics::prometheus::Prometheus;
 
 use ds::lock::Lock;
-use ds::time::{interval, timeout, Duration, Instant};
-use hyper::{header::CONTENT_TYPE, Body, Client, Request, Response, StatusCode};
+use ds::time::{Duration, Instant, interval, timeout};
+use hyper::{Body, Client, Request, Response, StatusCode, header::CONTENT_TYPE};
 use lazy_static::lazy_static;
 use tokio_util::io::ReaderStream;
 

--- a/agent/src/service.rs
+++ b/agent/src/service.rs
@@ -1,5 +1,5 @@
 use context::Quadruple;
-use ds::time::{sleep, Duration};
+use ds::time::{Duration, sleep};
 use net::Listener;
 use rt::spawn;
 use std::sync::Arc;

--- a/discovery/src/dns/mod.rs
+++ b/discovery/src/dns/mod.rs
@@ -4,18 +4,18 @@ use std::{
     future::Future,
     net::Ipv4Addr as IpAddr,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
 };
-use tokio::sync::mpsc::{unbounded_channel, UnboundedSender as Sender};
+use tokio::sync::mpsc::{UnboundedSender as Sender, unbounded_channel};
 
 mod lookup;
 use lookup::*;
 
 use ds::{
-    time::{interval, Duration},
     CowReadHandle, ReadGuard,
+    time::{Duration, interval},
 };
 static DNSCACHE: OnceCell<CowReadHandle<DnsCache>> = OnceCell::new();
 

--- a/discovery/src/topology.rs
+++ b/discovery/src/topology.rs
@@ -1,10 +1,10 @@
-use ds::{cow, CowReadHandle, CowWriteHandle};
+use ds::{CowReadHandle, CowWriteHandle, cow};
 
 use std::{
     ops::Deref,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
 };
 

--- a/discovery/src/update.rs
+++ b/discovery/src/update.rs
@@ -2,7 +2,7 @@ use metrics::Metric;
 // 定期更新discovery.
 use super::{Discover, TopologyWrite};
 use ds::chan::Receiver;
-use ds::time::{interval, Duration};
+use ds::time::{Duration, interval};
 
 use std::collections::HashMap;
 

--- a/discovery/src/vintage.rs
+++ b/discovery/src/vintage.rs
@@ -2,8 +2,8 @@
 
 use std::io::{Error, ErrorKind::Other};
 
-use ds::time::{timeout, Duration};
-use hyper::{client::HttpConnector, Client, Uri};
+use ds::time::{Duration, timeout};
+use hyper::{Client, Uri, client::HttpConnector};
 use serde::Deserialize;
 
 pub struct Vintage {

--- a/ds/src/decrypt.rs
+++ b/ds/src/decrypt.rs
@@ -1,4 +1,4 @@
-use rsa::{pkcs8::DecodePrivateKey, Pkcs1v15Encrypt, RsaPrivateKey};
+use rsa::{Pkcs1v15Encrypt, RsaPrivateKey, pkcs8::DecodePrivateKey};
 
 pub fn decrypt_password(
     key_pem: &String,

--- a/ds/src/mem/arena/ephemera.rs
+++ b/ds/src/mem/arena/ephemera.rs
@@ -1,5 +1,5 @@
 use std::{
-    alloc::{alloc, Layout},
+    alloc::{Layout, alloc},
     fmt::{Debug, Formatter},
     ptr::NonNull,
     sync::atomic::{AtomicU64, AtomicUsize, Ordering::*},

--- a/ds/src/mem/guarded.rs
+++ b/ds/src/mem/guarded.rs
@@ -1,6 +1,6 @@
 use std::sync::{
-    atomic::{AtomicUsize, Ordering::*},
     Arc,
+    atomic::{AtomicUsize, Ordering::*},
 };
 
 use crate::{ResizedRingBuffer, RingSlice};

--- a/ds/src/switcher.rs
+++ b/ds/src/switcher.rs
@@ -1,6 +1,6 @@
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc,
+    atomic::{AtomicBool, Ordering},
 };
 
 #[derive(Clone)]

--- a/endpoint/src/cacheservice/topo.rs
+++ b/endpoint/src/cacheservice/topo.rs
@@ -6,8 +6,8 @@ use protocol::{Protocol, Request, Resource::Memcache};
 use sharding::hash::{Hash, HashKey, Hasher};
 
 use super::config::Flag;
-use crate::shards::Shards;
 use crate::PerformanceTuning;
+use crate::shards::Shards;
 use protocol::Bit;
 
 #[derive(Clone)]

--- a/endpoint/src/dns.rs
+++ b/endpoint/src/dns.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering::*};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering::*};
 
 use discovery::dns::{self, IPPort};
 

--- a/endpoint/src/kv/config.rs
+++ b/endpoint/src/kv/config.rs
@@ -1,9 +1,9 @@
-use base64::{engine::general_purpose, Engine as _};
-use serde::{de::Error, Deserialize, Deserializer, Serialize};
+use base64::{Engine as _, engine::general_purpose};
+use serde::{Deserialize, Deserializer, Serialize, de::Error};
 use std::collections::HashMap;
 use std::fs;
 
-use crate::{Timeout, TO_MYSQL_M, TO_MYSQL_S};
+use crate::{TO_MYSQL_M, TO_MYSQL_S, Timeout};
 
 //时间间隔，闭区间, 可以是2010, 或者2010-2015
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]

--- a/endpoint/src/kv/mod.rs
+++ b/endpoint/src/kv/mod.rs
@@ -1,8 +1,8 @@
 pub(super) mod config;
 pub mod kvtime;
+pub(super) mod sql;
 pub mod strategy;
 pub mod topo;
 pub mod uuid;
-pub(super) mod sql;
 
 pub(crate) use protocol::kv::KVCtx;

--- a/endpoint/src/kv/topo.rs
+++ b/endpoint/src/kv/topo.rs
@@ -1,29 +1,29 @@
 use std::collections::HashMap;
 
+use discovery::TopologyWrite;
 use discovery::distance::ByDistance;
 use discovery::dns;
 use discovery::dns::IPPort;
-use discovery::TopologyWrite;
 use ds::MemGuard;
-use protocol::kv::Binary;
-use protocol::kv::ContextStatus;
-use protocol::kv::MysqlBuilder;
-use protocol::kv::Strategy;
 use protocol::Protocol;
 use protocol::Request;
 use protocol::ResOption;
 use protocol::Resource;
+use protocol::kv::Binary;
+use protocol::kv::ContextStatus;
+use protocol::kv::MysqlBuilder;
+use protocol::kv::Strategy;
 use rand::seq::SliceRandom;
 use sharding::hash::{Hash, HashKey};
 
-use crate::dns::DnsConfig;
 use crate::Timeout;
-use crate::{shards::Shard, Endpoint, Topology};
+use crate::dns::DnsConfig;
+use crate::{Endpoint, Topology, shards::Shard};
 
+use super::KVCtx;
 use super::config::KvNamespace;
 use super::config::Years;
 use super::strategy::Strategist;
-use super::KVCtx;
 #[derive(Clone)]
 pub struct KvService<E, P> {
     shards: Shards<E>,

--- a/endpoint/src/lib.rs
+++ b/endpoint/src/lib.rs
@@ -24,7 +24,7 @@ const TO_MYSQL_S: Timeout = Timeout::from_millis(500);
 const TO_VECTOR_M: Timeout = Timeout::from_millis(1000);
 const TO_VECTOR_S: Timeout = Timeout::from_millis(500);
 const TO_UUID: Timeout = Timeout::from_millis(100);
-const TO_MIN_MS: u32 = 20;  // timeout最小值，单位ms
+const TO_MIN_MS: u32 = 20; // timeout最小值，单位ms
 const TO_MAX_MS: u32 = 6000; // timeout最大值，单位ms
 
 #[derive(Copy, Clone, Debug)]

--- a/endpoint/src/msgque/strategy/round_robbin.rs
+++ b/endpoint/src/msgque/strategy/round_robbin.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter};
 
-use crate::{msgque::ReadStrategy, CloneableAtomicUsize};
+use crate::{CloneableAtomicUsize, msgque::ReadStrategy};
 use std::sync::atomic::Ordering::Relaxed;
 
 // const HITS_BITS: u32 = 8;

--- a/endpoint/src/msgque/topo.rs
+++ b/endpoint/src/msgque/topo.rs
@@ -9,11 +9,11 @@ use std::fmt::{Display, Formatter};
 use std::sync::atomic::Ordering::{Acquire, Release};
 use std::time::Instant;
 
-use super::config::Namespace;
 use super::Shard;
+use super::config::Namespace;
 use super::{
-    strategy::{Fixed, RoundRobbin},
     ReadStrategy, WriteStrategy,
+    strategy::{Fixed, RoundRobbin},
 };
 use crate::dns::{DnsConfig, DnsLookup};
 use crate::msgque::SizedQueueInfo;

--- a/endpoint/src/phantomservice/topo.rs
+++ b/endpoint/src/phantomservice/topo.rs
@@ -1,7 +1,7 @@
 use crate::{
+    Endpoint, Endpoints, Topology,
     dns::{DnsConfig, DnsLookup},
     select::Distance,
-    Endpoint, Endpoints, Topology,
 };
 use discovery::{Inited, TopologyWrite};
 use protocol::{Protocol, Request, Resource::Phantom};
@@ -71,7 +71,7 @@ where
 
         let mut ctx = super::Context::from(*req.context_mut());
         let idx = ctx.fetch_add_idx(); // 按顺序轮询
-                                       // 写操作，写所有实例
+        // 写操作，写所有实例
         req.write_back(req.operation().is_store() && ctx.index() < shard.len());
         // 读操作，只重试一次
         req.try_next(idx == 0);

--- a/endpoint/src/uuid/config.rs
+++ b/endpoint/src/uuid/config.rs
@@ -1,4 +1,4 @@
-use crate::{Timeout, TO_UUID};
+use crate::{TO_UUID, Timeout};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/endpoint/src/uuid/topo.rs
+++ b/endpoint/src/uuid/topo.rs
@@ -1,7 +1,7 @@
 use crate::{
+    Endpoint, Endpoints, PerformanceTuning, Topology,
     dns::{DnsConfig, DnsLookup},
     select::Distance,
-    Endpoint, Endpoints, PerformanceTuning, Topology,
 };
 use discovery::TopologyWrite;
 use protocol::{Protocol, Request, Resource::Uuid};

--- a/endpoint/src/vector/config.rs
+++ b/endpoint/src/vector/config.rs
@@ -1,10 +1,10 @@
-use base64::{engine::general_purpose, Engine as _};
+use base64::{Engine as _, engine::general_purpose};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 
 pub use crate::kv::config::Years;
-use crate::{Timeout, TO_VECTOR_M, TO_VECTOR_S};
+use crate::{TO_VECTOR_M, TO_VECTOR_S, Timeout};
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct VectorNamespace {

--- a/endpoint/src/vector/strategy.rs
+++ b/endpoint/src/vector/strategy.rs
@@ -238,8 +238,10 @@ mod tests {
         let db_idx = strategy.distribution().db_idx(hash);
         assert_eq!(
             buf,
-            &format!("select a,b from db_name_{db_idx}.table_name_2105 where `kid`='id' and `a`='1' and `b` in (2,3) group by b order by a,b desc limit 24 offset 12")
-            );
+            &format!(
+                "select a,b from db_name_{db_idx}.table_name_2105 where `kid`='id' and `a`='1' and `b` in (2,3) group by b order by a,b desc limit 24 offset 12"
+            )
+        );
 
         // vcard
         let vector_cmd = VectorCmd {
@@ -280,8 +282,10 @@ mod tests {
         let db_idx = strategy.distribution().db_idx(hash);
         assert_eq!(
             buf,
-            &format!("select count(*) from db_name_{db_idx}.table_name_2105 where `kid`='id' and `a`='1' and `b` in (2,3) order by a desc limit 24 offset 12")
-            );
+            &format!(
+                "select count(*) from db_name_{db_idx}.table_name_2105 where `kid`='id' and `a`='1' and `b` in (2,3) order by a desc limit 24 offset 12"
+            )
+        );
 
         //vadd
         let vector_cmd = VectorCmd {
@@ -373,7 +377,9 @@ mod tests {
         let db_idx = strategy.distribution().db_idx(hash);
         assert_eq!(
             buf,
-            &format!("update db_name_{db_idx}.table_name_2105 set `a`='1',`b`='bb' where `kid`='id' and `a`='1' and `b` in (2,3)")
+            &format!(
+                "update db_name_{db_idx}.table_name_2105 set `a`='1',`b`='bb' where `kid`='id' and `a`='1' and `b` in (2,3)"
+            )
         );
 
         //vdel
@@ -414,9 +420,11 @@ mod tests {
         println!("len: {}, act len: {}", builder.len(), buf.len());
         let db_idx = strategy.distribution().db_idx(hash);
         assert_eq!(
-                buf,
-                &format!("delete from db_name_{db_idx}.table_name_2105 where `kid`='id' and `a`='1' and `b` in (2,3)")
-                );
+            buf,
+            &format!(
+                "delete from db_name_{db_idx}.table_name_2105 where `kid`='id' and `a`='1' and `b` in (2,3)"
+            )
+        );
 
         // vget
         let vector_cmd = VectorCmd {
@@ -515,7 +523,9 @@ mod tests {
         let db_idx = strategy.distribution().db_idx(hash);
         assert_eq!(
             buf,
-            &format!("select a,b from db_name_{db_idx}.table_name_2105 where `kid`='id' and `a`='1' and `b` in (2,3) group by b order by a,b desc limit 24 offset 12")
-            );
+            &format!(
+                "select a,b from db_name_{db_idx}.table_name_2105 where `kid`='id' and `a`='1' and `b` in (2,3) group by b order by a,b desc limit 24 offset 12"
+            )
+        );
     }
 }

--- a/endpoint/src/vector/topo.rs
+++ b/endpoint/src/vector/topo.rs
@@ -1,26 +1,26 @@
 use std::collections::HashMap;
 
 use chrono::Datelike;
+use discovery::TopologyWrite;
 use discovery::dns;
 use discovery::dns::IPPort;
-use discovery::TopologyWrite;
 use ds::MemGuard;
-use protocol::kv::{ContextStatus, MysqlBuilder};
 use protocol::Protocol;
 use protocol::Request;
 use protocol::ResOption;
 use protocol::Resource;
+use protocol::kv::{ContextStatus, MysqlBuilder};
 use sharding::hash::{Hash, HashKey};
 
-use crate::dns::DnsConfig;
 use crate::Timeout;
+use crate::dns::DnsConfig;
 use crate::{Endpoint, Topology};
 use protocol::vector::mysql::SqlBuilder;
 
 use super::config::VectorNamespace;
 use super::strategy::Strategist;
-use crate::kv::topo::Shards;
 use crate::kv::KVCtx;
+use crate::kv::topo::Shards;
 use crate::shards::Shard;
 #[derive(Clone)]
 pub struct VectorService<E, P> {

--- a/endpoint/src/vector/vectortime.rs
+++ b/endpoint/src/vector/vectortime.rs
@@ -4,8 +4,8 @@ use super::strategy::Postfix;
 use chrono::NaiveDate;
 use core::fmt::Write;
 use ds::RingSlice;
-use protocol::kv::Strategy;
 use protocol::Error;
+use protocol::kv::Strategy;
 use sharding::{distribution::DBRange, hash::Hasher};
 
 #[derive(Clone, Debug)]

--- a/log/src/enable.rs
+++ b/log/src/enable.rs
@@ -63,10 +63,10 @@ pub fn private_api_enabled(level: Level, target: &str) -> bool {
 use elog::LevelFilter;
 use log4rs::{
     append::rolling_file::{
-        policy::compound::{
-            roll::fixed_window::FixedWindowRoller, trigger::size::SizeTrigger, CompoundPolicy,
-        },
         RollingFileAppender,
+        policy::compound::{
+            CompoundPolicy, roll::fixed_window::FixedWindowRoller, trigger::size::SizeTrigger,
+        },
     },
     config::{Appender, Config, Root},
     encode::pattern::PatternEncoder,

--- a/metrics/src/id.rs
+++ b/metrics/src/id.rs
@@ -66,7 +66,7 @@ impl Path {
     }
 }
 
-use crate::{types::Status, Count, Empty, Qps, Ratio, Rtt};
+use crate::{Count, Empty, Qps, Ratio, Rtt, types::Status};
 use enum_dispatch::enum_dispatch;
 #[enum_dispatch(Snapshot)]
 #[repr(u8)]

--- a/metrics/src/register.rs
+++ b/metrics/src/register.rs
@@ -1,4 +1,4 @@
-use ds::time::{interval, Duration};
+use ds::time::{Duration, interval};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -7,7 +7,7 @@ use crate::{Id, Item, ItemData, Metric};
 const CHUNK_SIZE: usize = 4096;
 
 use tokio::{
-    sync::mpsc::{unbounded_channel, UnboundedReceiver as Receiver, UnboundedSender as Sender},
+    sync::mpsc::{UnboundedReceiver as Receiver, UnboundedSender as Sender, unbounded_channel},
     time::Interval,
 };
 
@@ -211,7 +211,7 @@ impl Default for MetricRegister {
 use std::{
     future::Future,
     pin::Pin,
-    task::{ready, Context, Poll},
+    task::{Context, Poll, ready},
 };
 
 impl Future for MetricRegister {

--- a/metrics/src/types/host.rs
+++ b/metrics/src/types/host.rs
@@ -1,8 +1,8 @@
 use psutil::process::Process;
 
 use super::base::*;
-use crate::{ItemWriter, BASE_PATH};
-use ds::{time::Instant, Buffers, BUF_RX, BUF_TX};
+use crate::{BASE_PATH, ItemWriter};
+use ds::{BUF_RX, BUF_TX, Buffers, time::Instant};
 use std::sync::atomic::{AtomicI64, Ordering::*};
 
 static TASK_NUM: AtomicI64 = AtomicI64::new(0);

--- a/metrics/src/types/number.rs
+++ b/metrics/src/types/number.rs
@@ -1,4 +1,4 @@
-use super::{base::Adder, IncrTo, ItemData};
+use super::{IncrTo, ItemData, base::Adder};
 use crate::ItemWriter as Writer;
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]

--- a/metrics/src/types/ratio.rs
+++ b/metrics/src/types/ratio.rs
@@ -1,4 +1,4 @@
-use super::{base::Adder, Snapshot};
+use super::{Snapshot, base::Adder};
 use crate::{IncrTo, ItemData, ItemWriter as Writer};
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]

--- a/metrics/src/types/rtt.rs
+++ b/metrics/src/types/rtt.rs
@@ -1,6 +1,6 @@
 use ds::time::Duration;
 
-use super::{base::Adder, IncrTo, ItemData};
+use super::{IncrTo, ItemData, base::Adder};
 use crate::ItemWriter as Writer;
 pub const MAX: Duration = Duration::from_millis(30);
 const SLOW_US: i64 = Duration::from_millis(100).as_micros() as i64;

--- a/metrics/src/types/status.rs
+++ b/metrics/src/types/status.rs
@@ -1,4 +1,4 @@
-use super::{base::Adder, ItemData};
+use super::{ItemData, base::Adder};
 use crate::ItemWriter as Writer;
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -30,7 +30,7 @@ impl super::Snapshot for Status {
 }
 
 pub mod pub_status {
-    use crate::{base::Adder, IncrTo, ItemData};
+    use crate::{IncrTo, ItemData, base::Adder};
     // 0: ok
     // -1: error
     // 2..: notify

--- a/procs/src/deref.rs
+++ b/procs/src/deref.rs
@@ -1,7 +1,7 @@
 extern crate proc_macro;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, FnArg, ItemTrait, PatType, TraitItem, TraitItemMethod};
+use syn::{FnArg, ItemTrait, PatType, TraitItem, TraitItemMethod, parse_macro_input};
 
 // 在 trait 上添加 #[procs::dispatcher_trait_deref] 属性，则所有实现了Deref<T:Trait>的类型，都会自动实现该 trait
 pub fn impl_trait_for_deref_target(_attr: TokenStream, input: TokenStream) -> TokenStream {

--- a/procs/src/ds.rs
+++ b/procs/src/ds.rs
@@ -1,8 +1,8 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
-    parse_macro_input, punctuated::Punctuated, token::Comma, AttributeArgs, FnArg, Ident,
-    ItemTrait, NestedMeta, PatType, ReturnType, Type,
+    AttributeArgs, FnArg, Ident, ItemTrait, NestedMeta, PatType, ReturnType, Type,
+    parse_macro_input, punctuated::Punctuated, token::Comma,
 };
 
 #[derive(Clone, Copy)]

--- a/procs/src/endpoint.rs
+++ b/procs/src/endpoint.rs
@@ -1,9 +1,9 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
+    FnArg, ItemEnum, ItemTrait, PatType, Result, Token, TraitItem, Visibility, WhereClause,
     parse::{Parse, ParseStream},
-    parse_macro_input, FnArg, ItemEnum, ItemTrait, PatType, Result, Token, TraitItem, Visibility,
-    WhereClause,
+    parse_macro_input,
 };
 pub fn topology_dispatcher(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as TopologyInput);

--- a/protocol/src/kv/common/buffer_pool/mod.rs
+++ b/protocol/src/kv/common/buffer_pool/mod.rs
@@ -10,7 +10,7 @@ mod disabled;
 mod enabled;
 
 #[cfg(feature = "buffer-pool")]
-pub use enabled::{get_buffer, Buffer};
+pub use enabled::{Buffer, get_buffer};
 
 #[cfg(not(feature = "buffer-pool"))]
 pub use disabled::Buffer;

--- a/protocol/src/kv/common/misc/raw/_const.rs
+++ b/protocol/src/kv/common/misc/raw/_const.rs
@@ -18,7 +18,7 @@ use crate::kv::common::{
     proto::{MyDeserialize, MySerialize},
 };
 
-use super::{int::IntRepr, RawInt};
+use super::{RawInt, int::IntRepr};
 
 /// Same as `RawConst<T, U>` but holds `U` instead of `T`, i.e. holds the parsed value.
 ///

--- a/protocol/src/kv/common/misc/raw/bytes.rs
+++ b/protocol/src/kv/common/misc/raw/bytes.rs
@@ -19,7 +19,7 @@ use crate::kv::common::{
     proto::{MyDeserialize, MySerialize},
 };
 
-use super::{int::VarLen, RawInt};
+use super::{RawInt, int::VarLen};
 
 /// Wrapper for a raw byte sequence, that came from a server.
 ///

--- a/protocol/src/kv/common/misc/raw/flags.rs
+++ b/protocol/src/kv/common/misc/raw/flags.rs
@@ -16,7 +16,7 @@ use crate::kv::common::{
     proto::{MyDeserialize, MySerialize},
 };
 
-use super::{int::IntRepr, RawInt};
+use super::{RawInt, int::IntRepr};
 
 /// Wrapper for raw flags value.
 ///

--- a/protocol/src/kv/common/misc/raw/seq.rs
+++ b/protocol/src/kv/common/misc/raw/seq.rs
@@ -16,8 +16,8 @@ use crate::kv::common::{
 };
 
 use super::{
-    int::{IntRepr, LeU32, LeU64},
     RawInt,
+    int::{IntRepr, LeU32, LeU64},
 };
 
 // 序列号的values，目前不需要，有需要再考虑改为RingSlice fishermen

--- a/protocol/src/kv/common/packets/mod.rs
+++ b/protocol/src/kv/common/packets/mod.rs
@@ -24,20 +24,20 @@ use std::{
 use crate::kv::common::{
     constants::{
         CapabilityFlags, ColumnFlags, ColumnType, Command, CursorType, SessionStateType,
-        StatusFlags, StmtExecuteParamFlags, StmtExecuteParamsFlags, UTF8MB4_GENERAL_CI,
-        UTF8_GENERAL_CI,
+        StatusFlags, StmtExecuteParamFlags, StmtExecuteParamsFlags, UTF8_GENERAL_CI,
+        UTF8MB4_GENERAL_CI,
     },
     io::{BufMutExt, ParseBuf},
     misc::{
         lenenc_str_len,
         raw::{
-            bytes::{
-                BareBytes, ConstBytes, ConstBytesValue, EofBytes, LenEnc, NullBytes, U32Bytes,
-                U8Bytes,
-            },
-            int::{ConstU32, ConstU8, LeU16, LeU24, LeU32, LeU32LowerHalf, LeU32UpperHalf, LeU64},
-            seq::Seq,
             Const, Either, RawBytes, RawConst, RawInt, Skip,
+            bytes::{
+                BareBytes, ConstBytes, ConstBytesValue, EofBytes, LenEnc, NullBytes, U8Bytes,
+                U32Bytes,
+            },
+            int::{ConstU8, ConstU32, LeU16, LeU24, LeU32, LeU32LowerHalf, LeU32UpperHalf, LeU64},
+            seq::Seq,
         },
         unexpected_buf_eof,
     },

--- a/protocol/src/kv/common/packets/session_state_change.rs
+++ b/protocol/src/kv/common/packets/session_state_change.rs
@@ -3,7 +3,7 @@ use std::io;
 use crate::kv::common::{
     constants::SessionStateType,
     io::ParseBuf,
-    misc::raw::{bytes::EofBytes, int::LenEnc, RawBytes},
+    misc::raw::{RawBytes, bytes::EofBytes, int::LenEnc},
     proto::{MyDeserialize, MySerialize},
 };
 

--- a/protocol/src/kv/common/params.rs
+++ b/protocol/src/kv/common/params.rs
@@ -7,12 +7,12 @@
 // modified, or distributed except according to those terms.
 
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{HashMap, hash_map::Entry},
     error::Error,
     fmt,
 };
 
-use super::value::{convert::ToValue, Value};
+use super::value::{Value, convert::ToValue};
 
 /// `FromValue` conversion error.
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/protocol/src/kv/common/query_result.rs
+++ b/protocol/src/kv/common/query_result.rs
@@ -11,7 +11,7 @@ use std::{marker::PhantomData, sync::Arc};
 use crate::kv::common::packets::Column;
 use crate::kv::common::row::Row;
 
-use super::row::convert::{from_row, FromRow};
+use super::row::convert::{FromRow, from_row};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Or<A, B> {

--- a/protocol/src/kv/common/row/convert/frunk.rs
+++ b/protocol/src/kv/common/row/convert/frunk.rs
@@ -10,15 +10,15 @@
 
 #![cfg(feature = "frunk")]
 
-use frunk::{hlist::h_cons, prelude::HList};
 pub use frunk::{HCons, HNil};
+use frunk::{hlist::h_cons, prelude::HList};
 
 use super::{FromRow, FromRowError};
 use crate::{
-    row::{new_row_raw, Row},
+    row::{Row, new_row_raw},
     value::{
-        convert::{ConvIr, FromValue, FromValueError},
         Value,
+        convert::{ConvIr, FromValue, FromValueError},
     },
 };
 

--- a/protocol/src/kv/common/row/mod.rs
+++ b/protocol/src/kv/common/row/mod.rs
@@ -14,8 +14,8 @@ use crate::kv::common::{
     packets::{Column, NullBitmap},
     proto::{Binary, MyDeserialize, Text},
     value::{
-        convert::{from_value, from_value_opt, FromValue, FromValueError},
         BinValue, SerializationSide, TextValue, Value, ValueDeserializer,
+        convert::{FromValue, FromValueError, from_value, from_value_opt},
     },
 };
 use std::{fmt, io, marker::PhantomData, ops::Index, sync::Arc};

--- a/protocol/src/kv/common/value/convert/bigdecimal.rs
+++ b/protocol/src/kv/common/value/convert/bigdecimal.rs
@@ -71,7 +71,7 @@ mod tests {
     use bigdecimal::BigDecimal;
     use proptest::prelude::*;
 
-    use crate::value::{convert::from_value, Value};
+    use crate::value::{Value, convert::from_value};
 
     proptest! {
         #[test]

--- a/protocol/src/kv/common/value/convert/bigdecimal03.rs
+++ b/protocol/src/kv/common/value/convert/bigdecimal03.rs
@@ -71,7 +71,7 @@ mod tests {
     use bigdecimal03::BigDecimal;
     use proptest::prelude::*;
 
-    use crate::value::{convert::from_value, Value};
+    use crate::value::{Value, convert::from_value};
 
     proptest! {
         #[test]

--- a/protocol/src/kv/common/value/convert/bigint.rs
+++ b/protocol/src/kv/common/value/convert/bigint.rs
@@ -120,7 +120,7 @@ mod tests {
     use num_bigint::{BigInt, BigUint};
     use proptest::prelude::*;
 
-    use crate::kv::common::value::{convert::from_value, Value};
+    use crate::kv::common::value::{Value, convert::from_value};
 
     proptest! {
         #[test]

--- a/protocol/src/kv/common/value/convert/chrono.rs
+++ b/protocol/src/kv/common/value/convert/chrono.rs
@@ -15,7 +15,7 @@ use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use crate::value::Value;
 
 use super::{
-    parse_mysql_datetime_string, parse_mysql_time_string, ConvIr, FromValueError, ParseIr,
+    ConvIr, FromValueError, ParseIr, parse_mysql_datetime_string, parse_mysql_time_string,
 };
 
 impl ConvIr<NaiveDateTime> for ParseIr<NaiveDateTime> {
@@ -164,11 +164,7 @@ impl ConvIr<chrono::Duration> for ParseIr<chrono::Duration> {
                             + chrono::Duration::minutes(minutes.into())
                             + chrono::Duration::seconds(seconds.into())
                             + chrono::Duration::microseconds(microseconds.into());
-                        if is_neg {
-                            -duration
-                        } else {
-                            duration
-                        }
+                        if is_neg { -duration } else { duration }
                     }
                     _ => return Err(FromValueError(Value::Bytes(val_bytes))),
                 };

--- a/protocol/src/kv/common/value/convert/decimal.rs
+++ b/protocol/src/kv/common/value/convert/decimal.rs
@@ -12,7 +12,7 @@
 
 use rust_decimal::Decimal;
 
-use std::str::{from_utf8, FromStr};
+use std::str::{FromStr, from_utf8};
 
 use super::{ConvIr, FromValue, FromValueError, ParseIr, Value};
 

--- a/protocol/src/kv/common/value/convert/time.rs
+++ b/protocol/src/kv/common/value/convert/time.rs
@@ -16,7 +16,7 @@ use time::{Date, ParseError, PrimitiveDateTime, Time};
 
 use crate::value::Value;
 
-use super::{parse_mysql_time_string, ConvIr, FromValueError, ParseIr};
+use super::{ConvIr, FromValueError, ParseIr, parse_mysql_time_string};
 
 impl ConvIr<PrimitiveDateTime> for ParseIr<PrimitiveDateTime> {
     fn new(value: Value) -> Result<ParseIr<PrimitiveDateTime>, FromValueError> {
@@ -194,11 +194,7 @@ impl ConvIr<time::Duration> for ParseIr<time::Duration> {
                             + time::Duration::minutes(minutes.into())
                             + time::Duration::seconds(seconds.into())
                             + time::Duration::microseconds(microseconds.into());
-                        if is_neg {
-                            -duration
-                        } else {
-                            duration
-                        }
+                        if is_neg { -duration } else { duration }
                     }
                     _ => return Err(FromValueError(Value::Bytes(val_bytes))),
                 };

--- a/protocol/src/kv/common/value/convert/time03.rs
+++ b/protocol/src/kv/common/value/convert/time03.rs
@@ -13,17 +13,17 @@
 use std::{cmp::Ordering, convert::TryFrom, str::from_utf8};
 
 use time03::{
+    Date, PrimitiveDateTime, Time,
     error::{Parse, TryFromParsed},
     format_description::{
-        modifier::{self, Subsecond},
         Component, FormatItem,
+        modifier::{self, Subsecond},
     },
-    Date, PrimitiveDateTime, Time,
 };
 
 use crate::value::Value;
 
-use super::{parse_mysql_time_string, ConvIr, FromValueError, ParseIr};
+use super::{ConvIr, FromValueError, ParseIr, parse_mysql_time_string};
 
 lazy_static::lazy_static! {
     static ref FULL_YEAR: modifier::Year = {
@@ -294,11 +294,7 @@ impl ConvIr<time03::Duration> for ParseIr<time03::Duration> {
                             + time03::Duration::minutes(minutes.into())
                             + time03::Duration::seconds(seconds.into())
                             + time03::Duration::microseconds(microseconds.into());
-                        if is_neg {
-                            -duration
-                        } else {
-                            duration
-                        }
+                        if is_neg { -duration } else { duration }
                     }
                     _ => return Err(FromValueError(Value::Bytes(val_bytes))),
                 };

--- a/protocol/src/kv/common/value/json/serde_integration.rs
+++ b/protocol/src/kv/common/value/json/serde_integration.rs
@@ -8,10 +8,10 @@
 
 use super::{Deserialized, DeserializedIr, Serialized};
 use crate::kv::common::value::{
-    convert::{ConvIr, FromValue, FromValueError},
     Value,
+    convert::{ConvIr, FromValue, FromValueError},
 };
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use serde_json::{self, Value as Json};
 use std::str::{from_utf8, from_utf8_unchecked};
 

--- a/protocol/src/kv/mc2mysql.rs
+++ b/protocol/src/kv/mc2mysql.rs
@@ -2,9 +2,9 @@ use core::fmt::Write;
 use std::fmt::Display;
 
 use super::common::proto::codec::PacketCodec;
+use crate::HashedCommand;
 use crate::kv::MysqlBinary;
 use crate::kv::{Binary, OP_ADD, OP_DEL, OP_GET, OP_GETK, OP_SET};
-use crate::HashedCommand;
 use crate::{Error::FlushOnClose, Result};
 use ds::{RingSlice, Utf8};
 use sharding::{distribution::DBRange, hash::Hasher};

--- a/protocol/src/kv/rsppacket.rs
+++ b/protocol/src/kv/rsppacket.rs
@@ -6,16 +6,16 @@ use crate::{Command, StreamContext};
 use super::client::Client;
 use super::common::{buffer_pool::Buffer, proto::codec::PacketCodec, query_result::Or};
 
+use super::HandShakeStatus;
 use super::error::Error;
 use super::error::Result;
 use super::packet::PacketData;
-use super::HandShakeStatus;
 
 use bytes::BytesMut;
 use core::num::NonZeroUsize;
 use std::fmt::{self, Debug, Display, Formatter};
 
-use super::common::constants::{StatusFlags, MAX_PAYLOAD_LEN};
+use super::common::constants::{MAX_PAYLOAD_LEN, StatusFlags};
 use super::common::error::DriverError;
 use super::common::packets::{
     AuthPlugin, Column, CommonOkPacket, HandshakeResponse, OkPacket, OkPacketDeserializer,

--- a/protocol/src/req.rs
+++ b/protocol/src/req.rs
@@ -1,8 +1,8 @@
 use ds::time::Instant;
 use std::fmt::{Debug, Display};
 use std::ops::{Deref, DerefMut};
-use std::sync::atomic::{AtomicUsize, Ordering::*};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering::*};
 
 use crate::{Command, HashedCommand};
 

--- a/protocol/src/request.rs
+++ b/protocol/src/request.rs
@@ -1,4 +1,4 @@
-use crate::{callback::CallbackContext, BackendQuota, Command, Context, Error, HashedCommand};
+use crate::{BackendQuota, Command, Context, Error, HashedCommand, callback::CallbackContext};
 use std::{
     fmt::{self, Debug, Display, Formatter},
     ptr::NonNull,

--- a/protocol/src/vector/command.rs
+++ b/protocol/src/vector/command.rs
@@ -1,4 +1,4 @@
-use crate::{redis::command::CommandHasher, OpCode, Operation, Result};
+use crate::{OpCode, Operation, Result, redis::command::CommandHasher};
 
 // 指令参数需要配合实际请求的token数进行调整，所以外部使用都通过方法获取
 #[derive(Default, Debug)]

--- a/protocol/src/vector/mod.rs
+++ b/protocol/src/vector/mod.rs
@@ -20,9 +20,9 @@ use sharding::hash::Hash;
 
 use self::reqpacket::RequestPacket;
 use self::rsppacket::ResponsePacket;
+use crate::HandShake;
 use crate::kv::client::Client;
 use crate::kv::{ContextStatus, HandShakeStatus};
-use crate::HandShake;
 pub use command::CommandType;
 
 #[derive(Clone, Default)]

--- a/protocol/src/vector/packet.rs
+++ b/protocol/src/vector/packet.rs
@@ -6,10 +6,10 @@ use ds::{ByteOrder, RingSlice};
 
 use crate::kv::{
     common::{
+        ParseBuf,
         constants::{CapabilityFlags, StatusFlags},
         error::Error::MySqlError,
         packets::{ErrPacket, OkPacket, OkPacketDeserializer, OkPacketKind},
-        ParseBuf,
     },
     error::{Error, Result},
 };

--- a/protocol/src/vector/query_result.rs
+++ b/protocol/src/vector/query_result.rs
@@ -12,9 +12,9 @@ use std::marker::PhantomData;
 use crate::kv::common::packets::{Column, OldEofPacket, ResultSetTerminator};
 use crate::kv::common::query_result::{Or, SetIteratorState};
 use crate::kv::common::row::Row;
+use SetIteratorState::*;
 use bytes::BufMut;
 use ds::Utf8;
-use SetIteratorState::*;
 
 const CRLF: &[u8] = b"\r\n";
 

--- a/protocol/src/vector/rsppacket.rs
+++ b/protocol/src/vector/rsppacket.rs
@@ -3,9 +3,10 @@
 use bytes::BytesMut;
 use std::fmt::{self, Debug, Display, Formatter};
 
+use crate::kv::HandShakeStatus;
 use crate::kv::client::Client;
-use crate::kv::common::constants::StatusFlags;
 use crate::kv::common::constants::DEFAULT_MAX_ALLOWED_PACKET;
+use crate::kv::common::constants::StatusFlags;
 use crate::kv::common::error::DriverError;
 use crate::kv::common::io::ReadMysqlExt;
 use crate::kv::common::packets::{AuthPlugin, Column, CommonOkPacket, HandshakeResponse, OkPacket};
@@ -14,7 +15,6 @@ use crate::kv::common::{constants::CapabilityFlags, io::ParseBuf, packets::Hands
 use crate::kv::common::{proto::codec::PacketCodec, query_result::Or};
 use crate::kv::error::Error;
 use crate::kv::error::Result;
-use crate::kv::HandShakeStatus;
 use crate::{Command, StreamContext};
 use ds::RingSlice;
 

--- a/rt/src/entry.rs
+++ b/rt/src/entry.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{ready, Context, Poll};
+use std::task::{Context, Poll, ready};
 
 use super::timeout::*;
 
-use ds::time::{interval, Duration, Instant, Interval};
+use ds::time::{Duration, Instant, Interval, interval};
 
 use tokio::io::{AsyncRead, AsyncWrite};
 

--- a/rt/src/stream/mod.rs
+++ b/rt/src/stream/mod.rs
@@ -3,7 +3,7 @@ use metric::MetricStream;
 
 use std::io;
 use std::pin::Pin;
-use std::task::{ready, Context, Poll, Waker};
+use std::task::{Context, Poll, Waker, ready};
 
 use ds::{GuardedBuffer, MemGuard, MemPolicy, RingSlice};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};

--- a/rt/src/stream/reader.rs
+++ b/rt/src/stream/reader.rs
@@ -23,11 +23,7 @@ impl<'a, C> Reader<'a, C> {
     // 如果eof了，则返回错误，否则返回读取的num数量
     #[inline(always)]
     pub(crate) fn check(&self) -> Result<()> {
-        if self.n > 0 {
-            Ok(())
-        } else {
-            Err(Error::Eof)
-        }
+        if self.n > 0 { Ok(()) } else { Err(Error::Eof) }
     }
 }
 

--- a/rt/src/stream/tx_buf.rs
+++ b/rt/src/stream/tx_buf.rs
@@ -3,7 +3,7 @@ use metrics::base::*;
 use super::MemPolicy;
 use std::{
     mem::ManuallyDrop,
-    ptr::{copy_nonoverlapping as copy, NonNull},
+    ptr::{NonNull, copy_nonoverlapping as copy},
 };
 // 最大支持u32::MAX大小的buffer。
 #[derive(Debug)]

--- a/rt/src/timeout.rs
+++ b/rt/src/timeout.rs
@@ -1,6 +1,6 @@
-use std::task::{ready, Context, Poll};
+use std::task::{Context, Poll, ready};
 
-use ds::time::{interval, Duration, Interval};
+use ds::time::{Duration, Interval, interval};
 
 use super::entry::ReEnter;
 

--- a/sharding/src/distribution/modrange.rs
+++ b/sharding/src/distribution/modrange.rs
@@ -31,7 +31,11 @@ impl ModRange {
         let rs = val as u64 / self.interval;
         if rs >= self.shards as u64 {
             // 超出范围，返回最后一个分片
-            log::warn!("found modrange slot out of bound, rs:{}, shards:{}", rs, self.shards);
+            log::warn!(
+                "found modrange slot out of bound, rs:{}, shards:{}",
+                rs,
+                self.shards
+            );
             return self.shards - 1;
         }
         rs as usize

--- a/sharding/src/distribution/range.rs
+++ b/sharding/src/distribution/range.rs
@@ -32,7 +32,11 @@ impl Range {
         let rs = val as u64 / self.interval;
         if rs >= self.shards as u64 {
             // 超出范围，返回最后一个分片
-            log::warn!("found range slot out of bound, rs:{}, shards:{}", rs, self.shards);
+            log::warn!(
+                "found range slot out of bound, rs:{}, shards:{}",
+                rs,
+                self.shards
+            );
             return self.shards - 1;
         }
         rs as usize

--- a/sharding/src/hash/bkdrabscrc32.rs
+++ b/sharding/src/hash/bkdrabscrc32.rs
@@ -1,4 +1,4 @@
-use super::{bkdr::Bkdr, crc32::Crc32, Hash};
+use super::{Hash, bkdr::Bkdr, crc32::Crc32};
 
 /// key：${num}#suffix，对数字部分进行 bkdr + abs + crc32；属小众业务算法。
 /// 对于i32溢出，一般有类型提升 vs abs两种策略，bkdr自身是有abs，但考虑避免后面bkdr符号变化的影响，此处仍然进行abs；

--- a/sharding/src/hash/crc.rs
+++ b/sharding/src/hash/crc.rs
@@ -1,4 +1,4 @@
-use super::{Hash, HashKey, CRC32TAB, CRC_SEED};
+use super::{CRC_SEED, CRC32TAB, Hash, HashKey};
 #[derive(Default)]
 pub struct Crc32Hasher<A, B, C, D> {
     range: A,  // 用于截取key的范围

--- a/sharding/src/hash/crc32local.rs
+++ b/sharding/src/hash/crc32local.rs
@@ -3,8 +3,8 @@
 use std::fmt::Display;
 
 use super::{
-    crc32::{self, CRC32TAB, CRC_SEED},
     DebugName, Hash,
+    crc32::{self, CRC_SEED, CRC32TAB},
 };
 
 #[derive(Default, Clone, Debug)]

--- a/sharding/src/hash/lbcrc32local.rs
+++ b/sharding/src/hash/lbcrc32local.rs
@@ -3,8 +3,8 @@
 use std::fmt::Display;
 
 use super::{
-    crc32::{CRC32TAB, CRC_SEED},
     DebugName,
+    crc32::{CRC_SEED, CRC32TAB},
 };
 
 // LBCrc32local算法，需要先转为u64的bytes，然后再计算hash

--- a/sharding/src/hash/mod.rs
+++ b/sharding/src/hash/mod.rs
@@ -84,7 +84,7 @@ pub enum Hasher {
     Rawcrc32local(Rawcrc32local),                 // raw or crc32local
     Crc32Abs(Crc32Abs), // crc32abs: 基于i32转换，然后直接取abs；其他走i64提升为正数
     Crc32AbsDelimiter(Crc32AbsDelimiter), // crc32abs: 基于i32转换，然后直接取abs，同时支持分隔符，格式：$start+$hashkey+$delimiter$
-    Crc64(Crc64),       // Crc64 算法，对整个key做crc64计算
+    Crc64(Crc64),                         // Crc64 算法，对整个key做crc64计算
     Fnv1aF64(Fnv1aF64),
     Random(RandomHash), // random hash
     RawSuffix(RawSuffix),

--- a/stream/src/builder.rs
+++ b/stream/src/builder.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ds::chan::mpsc::{channel, Sender, TrySendError};
+use ds::chan::mpsc::{Sender, TrySendError, channel};
 
 use ds::Switcher;
 

--- a/stream/src/context.rs
+++ b/stream/src/context.rs
@@ -1,8 +1,8 @@
 use std::{marker::PhantomData, ptr::NonNull, sync::Arc};
 
 use protocol::{
-    callback::CallbackContext, request::Request, Command, Commander, HashedCommand, Metric,
-    MetricItem, Protocol,
+    Command, Commander, HashedCommand, Metric, MetricItem, Protocol, callback::CallbackContext,
+    request::Request,
 };
 
 use crate::arena::CallbackContextArena;

--- a/stream/src/handler.rs
+++ b/stream/src/handler.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{ready, Context, Poll};
+use std::task::{Context, Poll, ready};
 
 use ds::chan::mpsc::Receiver;
 use ds::time::Instant;

--- a/stream/src/metric.rs
+++ b/stream/src/metric.rs
@@ -1,5 +1,5 @@
 use metrics::{Metric, Path};
-use protocol::{Metric as ProtoMetric, MetricName, Operation, OPS};
+use protocol::{Metric as ProtoMetric, MetricName, OPS, Operation};
 macro_rules! define_metrics {
     ($($t:ident:$($name:ident-$key:expr),+);+) => {
         pub struct StreamMetrics {

--- a/stream/src/pipeline.rs
+++ b/stream/src/pipeline.rs
@@ -3,21 +3,21 @@ use std::{
     future::Future,
     pin::Pin,
     sync::Arc,
-    task::{ready, Context, Poll},
+    task::{Context, Poll, ready},
 };
 
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 
 use crate::topology::TopologyCheck;
-use ds::{time::Instant, AtomicWaker};
+use ds::{AtomicWaker, time::Instant};
 use endpoint::Topology;
 use protocol::Error::FlushOnClose;
 use protocol::{HashedCommand, Protocol, Result, Stream};
 
 use crate::{
+    CallbackContext, Request, StreamMetrics,
     arena::CallbackContextArena,
     context::{CallbackContextPtr, ResponseContext},
-    CallbackContext, Request, StreamMetrics,
 };
 
 pub async fn copy_bidirectional<C, P, T>(

--- a/stream/src/reconn.rs
+++ b/stream/src/reconn.rs
@@ -1,4 +1,4 @@
-use ds::time::{sleep, Duration};
+use ds::time::{Duration, sleep};
 pub(crate) struct ReconnPolicy {
     conns: usize,
     continue_fails: usize,

--- a/tests/src/benches/arena.rs
+++ b/tests/src/benches/arena.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicU64, Ordering::*};
 
-use criterion::{black_box, Criterion};
+use criterion::{Criterion, black_box};
 
 use ds::arena::{Allocator, Heap};
 pub(super) fn bench_alloc(c: &mut Criterion) {

--- a/tests/src/benches/heap.rs
+++ b/tests/src/benches/heap.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, Criterion};
+use criterion::{Criterion, black_box};
 pub(super) fn bench_get_checked(c: &mut Criterion) {
     let slice = (0..64).into_iter().map(|x| x as u8).collect::<Vec<u8>>();
     let len = slice.len();

--- a/tests/src/benches/ring_slice.rs
+++ b/tests/src/benches/ring_slice.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, Criterion};
+use criterion::{Criterion, black_box};
 use ds::{ByteOrder, RingSlice};
 pub(super) fn bench_iter(c: &mut Criterion) {
     let cap = 128;

--- a/tests/src/benches/time.rs
+++ b/tests/src/benches/time.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, Criterion};
+use criterion::{Criterion, black_box};
 pub(super) fn bench_instant(c: &mut Criterion) {
     let mut group = c.benchmark_group("time_instant");
     group.bench_function("std", |b| {

--- a/tests/src/decrypt.rs
+++ b/tests/src/decrypt.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose, Engine as _};
+use base64::{Engine as _, engine::general_purpose};
 use ds::decrypt::decrypt_password;
 
 /// 测试场景：正常&异常解密密码

--- a/tests/src/kv/mod.rs
+++ b/tests/src/kv/mod.rs
@@ -1,7 +1,7 @@
+use protocol::kv::common::value::Value;
 use protocol::kv::common::value::convert::duration::MyDuration;
 use protocol::kv::common::value::convert::regex::parse_mysql_time_string;
-use protocol::kv::common::value::convert::{from_value, from_value_opt, FromValue};
-use protocol::kv::common::value::Value;
+use protocol::kv::common::value::convert::{FromValue, from_value, from_value_opt};
 
 use proptest::proptest;
 

--- a/tests/src/kv/value.rs
+++ b/tests/src/kv/value.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use protocol::kv::common::{value::Value, ParseBuf};
+use protocol::kv::common::{ParseBuf, value::Value};
 
 #[test]
 fn should_escape_string() {
@@ -137,8 +137,8 @@ mod benches {
 
 #[test]
 fn mysql_simple_issue_284() -> io::Result<()> {
-    use ds::RingSlice;
     use Value::*;
+    use ds::RingSlice;
 
     let data = vec![1, 49, 1, 50, 1, 51, 251, 1, 52, 1, 53, 251, 1, 55];
     let slice = RingSlice::from_vec(&data);

--- a/tests/src/layout.rs
+++ b/tests/src/layout.rs
@@ -1,7 +1,7 @@
 // 不要轻易变更这里面的测试用例，除非你知道你在做什么。拉相关同学进行方案评审。
 use std::mem::size_of;
 
-use protocol::{callback::CallbackContext, Parser};
+use protocol::{Parser, callback::CallbackContext};
 use stream::{Backend, BackendInner, Request};
 type Endpoint = Backend<Request>;
 type Topology = endpoint::TopologyProtocol<Endpoint, Parser>;

--- a/tests/src/mq/mod.rs
+++ b/tests/src/mq/mod.rs
@@ -1,11 +1,11 @@
 use std::collections::HashSet;
 
-use endpoint::msgque::strategy::Fixed;
-/// 验证读写策略，离线策略
-use endpoint::msgque::strategy::RoundRobbin;
 use endpoint::msgque::ReadStrategy;
 use endpoint::msgque::SizedQueueInfo;
 use endpoint::msgque::WriteStrategy;
+use endpoint::msgque::strategy::Fixed;
+/// 验证读写策略，离线策略
+use endpoint::msgque::strategy::RoundRobbin;
 use rand::random;
 
 mod protocol;

--- a/tests/src/mq/protocol.rs
+++ b/tests/src/mq/protocol.rs
@@ -1,7 +1,7 @@
 use crate::proto_hook;
 use protocol::{
-    msgque::{MsgQue, OP_GET, OP_QUIT, OP_SET, OP_STATS, OP_VERSION},
     Error, Proto,
+    msgque::{MsgQue, OP_GET, OP_QUIT, OP_SET, OP_STATS, OP_VERSION},
 };
 
 use protocol::BufRead;

--- a/tests/src/select.rs
+++ b/tests/src/select.rs
@@ -1,5 +1,5 @@
 use discovery::distance::Addr;
-use endpoint::{select::Distance, Endpoint};
+use endpoint::{Endpoint, select::Distance};
 struct TBackend {
     addr: String,
     available: bool,

--- a/tests/src/shard_checker.rs
+++ b/tests/src/shard_checker.rs
@@ -266,7 +266,9 @@ fn check_readed_redis_hasher() {
     for entry in files {
         let path = entry.path();
         let fname = path.file_name().unwrap().to_string_lossy();
-        if !fname.ends_with(".txt") { continue; }
+        if !fname.ends_with(".txt") {
+            continue;
+        }
         let port: u16 = match fname.trim_end_matches(".txt").parse() {
             Ok(p) => p,
             Err(_) => continue,
@@ -280,12 +282,17 @@ fn check_readed_redis_hasher() {
         for line in reader.lines() {
             let key = line.unwrap();
             let key = key.trim();
-            if key.is_empty() { continue; }
+            if key.is_empty() {
+                continue;
+            }
             // shards[idx].push(key.to_string());
             let hash = hasher.hash(&key.as_bytes());
             let shard_idx = dist.index(hash);
             if shard_idx != idx {
-                println!("key={} hash={} shard_idx={} file={} idx={}", key, hash, shard_idx, fname, idx);
+                println!(
+                    "key={} hash={} shard_idx={} file={} idx={}",
+                    key, hash, shard_idx, fname, idx
+                );
             }
         }
         println!("已处理端口文件: {}", path.display());
@@ -302,5 +309,4 @@ fn check_crc32abs_hasher() {
     let hash = hasher.hash(&key.as_bytes());
     let idx = dist.index(hash);
     println!("key: {}, hash: {}, idx: {}", key, hash, idx);
-
 }

--- a/tests_integration/src/mc/mod.rs
+++ b/tests_integration/src/mc/mod.rs
@@ -36,9 +36,11 @@ fn buffer_capacity_a() {
     v_sizes = [0, 4, 40, 400, 4000, 8000, 20000, 1048507];
     for v_size in v_sizes {
         let val = vec![0x41; v_size];
-        assert!(client
-            .set(key, &String::from_utf8_lossy(&val).to_string(), 2)
-            .is_ok());
+        assert!(
+            client
+                .set(key, &String::from_utf8_lossy(&val).to_string(), 2)
+                .is_ok()
+        );
         let result: Result<Option<String>, MemcacheError> = client.get(key);
         assert!(result.is_ok());
         assert_eq!(


### PR DESCRIPTION
关联任务：1018335_1#57653 weekly-report同步稳定性优化

## Summary
- Run `cargo fmt --all` across the Rust workspace
- Keep the change limited to formatting: import ordering, indentation, line wrapping, and whitespace
- No dependency version changes

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace`

Note: `cargo check --workspace` still reports the existing third-party future-incompat warning for `num-bigint-dig v0.8.4`; dependency versions were intentionally left unchanged.